### PR TITLE
OSS Rebuild collector

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -16,6 +16,7 @@ import (
 	"github.com/carabiner-dev/collector/repository/http"
 	"github.com/carabiner-dev/collector/repository/jsonl"
 	"github.com/carabiner-dev/collector/repository/note"
+	"github.com/carabiner-dev/collector/repository/ossrebuild"
 	"github.com/carabiner-dev/collector/repository/release"
 )
 
@@ -60,11 +61,12 @@ func LoadDefaultRepositoryTypes() error {
 	errs := []error{}
 	for t, factory := range map[string]RepositoryFactory{
 		filesystem.TypeMoniker: filesystem.Build,
-		jsonl.TypeMoniker:      jsonl.Build,
 		github.TypeMoniker:     github.Build,
 		http.TypeMoniker:       http.Build,
-		release.TypeMoniker:    release.Build,
+		jsonl.TypeMoniker:      jsonl.Build,
 		note.TypeMoniker:       note.Build,
+		ossrebuild.TypeMoniker: ossrebuild.Build,
+		release.TypeMoniker:    release.Build,
 	} {
 		if err := RegisterCollectorType(t, factory); err != nil {
 			if !errors.Is(err, ErrTypeAlreadyRegistered) {

--- a/repository/http/fetchers.go
+++ b/repository/http/fetchers.go
@@ -30,8 +30,9 @@ func fetchGeneral(_ context.Context, opts *Options, _ attestation.FetchOptions) 
 	datas, errs := a.GetGroup(opts.URLs)
 	for i := range datas {
 		if errs[i] != nil {
+			// Don't take 404 as an error
 			if strings.Contains(errs[i].Error(), "HTTP error 404") {
-				return []attestation.Envelope{}, nil
+				continue
 			}
 			return nil, fmt.Errorf("fetching http data: %w", errs[i])
 		}

--- a/repository/ossrebuild/ossrebuild.go
+++ b/repository/ossrebuild/ossrebuild.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package http implements an attestations collector that reads
+// data from an https endpoint.
+package ossrebuild
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/carabiner-dev/attestation"
+	gopurl "github.com/package-url/packageurl-go"
+
+	"github.com/carabiner-dev/collector/repository/http"
+)
+
+var (
+	_ attestation.Fetcher          = (*Collector)(nil)
+	_ attestation.FetcherBySubject = (*Collector)(nil)
+)
+
+var TypeMoniker = "http"
+
+// Implement the factory function
+var Build = func(uriString string) (attestation.Repository, error) {
+	return New()
+}
+
+// Ensure the collector variants implement the interfaces
+var (
+	_ attestation.Fetcher          = (*Collector)(nil)
+	_ attestation.FetcherBySubject = (*Collector)(nil)
+)
+
+// New creates a new collector. The type of collector returned varies according
+// to the specified URL templates.
+func New() (*Collector, error) {
+	return &Collector{}, nil
+}
+
+// Collector is the general collector that supports fetching from the OSS rebuild repo
+type Collector struct{}
+
+func (c *Collector) Fetch(ctx context.Context, opts attestation.FetchOptions) ([]attestation.Envelope, error) {
+	return nil, nil
+}
+
+func subjectsToOssRebuildURLS(subjects []attestation.Subject) []string {
+	urls := []string{}
+	for _, subject := range subjects {
+		if !strings.Contains(subject.GetUri(), "pkg:") {
+			continue
+		}
+
+		// Parse the package URL. For now we only support npm
+		// pkg:npm/%40alloc/quick-lru@5.2.0
+		purl, err := gopurl.FromString(subject.GetUri())
+		if err != nil {
+			// This is not a package URL, continue
+			continue
+		}
+
+		switch purl.Type {
+		case "npm":
+			filename := purl.Name
+			directory := purl.Name
+			if purl.Namespace != "" {
+				filename = strings.TrimPrefix(purl.Namespace, "@") + "-" + purl.Name
+				directory = purl.Namespace + "/" + purl.Name
+			}
+
+			urls = append(urls,
+				fmt.Sprintf(
+					"https://storage.googleapis.com/google-rebuild-attestations/%s/%s/%s/%s-%s.tgz/rebuild.intoto.jsonl",
+					purl.Type, directory, purl.Version, filename, purl.Version,
+				))
+		default:
+			// Type not supported yet
+			continue
+		}
+	}
+	return urls
+}
+
+// FetchBySubject is the only method implemented. It fetches by getting a
+// purl in the subject's URI
+func (c *Collector) FetchBySubject(ctx context.Context, fo attestation.FetchOptions, subjects []attestation.Subject) ([]attestation.Envelope, error) {
+	urls := subjectsToOssRebuildURLS(subjects)
+
+	// Piggy back on the http collector to fetch
+	hcollector, err := http.New(http.WithURL(urls...))
+	if err != nil {
+		return nil, err
+	}
+
+	return hcollector.Fetch(ctx, fo)
+}

--- a/repository/ossrebuild/ossrebuild_test.go
+++ b/repository/ossrebuild/ossrebuild_test.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package ossrebuild
+
+import (
+	"testing"
+
+	"github.com/carabiner-dev/attestation"
+	intoto "github.com/in-toto/attestation/go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBySubject(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name        string
+		subjects    []attestation.Subject
+		mustErr     bool
+		expectedNum int
+	}{
+		{"one-package", []attestation.Subject{&intoto.ResourceDescriptor{Uri: "pkg:npm/read@1.0.7"}}, false, 2},
+		{"two-packages", []attestation.Subject{
+			&intoto.ResourceDescriptor{Uri: "pkg:npm/read@1.0.7"},
+			&intoto.ResourceDescriptor{Uri: "pkg:npm/websocket@1.0.35"},
+		}, false, 4},
+		{"test-404-dont-fail", []attestation.Subject{&intoto.ResourceDescriptor{Uri: "pkg:npm/read@1.0.0"}}, false, 0},
+		{"one-package-one-404", []attestation.Subject{
+			&intoto.ResourceDescriptor{Uri: "pkg:npm/walk@2.3.15"}, // real
+			&intoto.ResourceDescriptor{Uri: "pkg:npm/read@1.0.0"},  // 404
+		}, false, 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			collector, err := New()
+			require.NoError(t, err)
+
+			atts, err := collector.FetchBySubject(t.Context(), attestation.FetchOptions{}, tt.subjects)
+			if tt.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, atts, tt.expectedNum)
+		})
+	}
+}
+
+func TestSubjectsToUrls(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		subjects []attestation.Subject
+		expect   []string
+	}{
+		{
+			"one",
+			[]attestation.Subject{&intoto.ResourceDescriptor{Uri: "pkg:npm/binary-extensions@2.3.0"}},
+			[]string{"https://storage.googleapis.com/google-rebuild-attestations/npm/binary-extensions/2.3.0/binary-extensions-2.3.0.tgz/rebuild.intoto.jsonl"},
+		},
+		{
+			"existing",
+			[]attestation.Subject{&intoto.ResourceDescriptor{Uri: "pkg:npm/yaml@2.4.2"}},
+			[]string{"https://storage.googleapis.com/google-rebuild-attestations/npm/yaml/2.4.2/yaml-2.4.2.tgz/rebuild.intoto.jsonl"},
+		},
+		{
+			"namespaced",
+			[]attestation.Subject{&intoto.ResourceDescriptor{Uri: "pkg:npm/%40tanstack/vue-virtual@3.5.0"}},
+			[]string{"https://storage.googleapis.com/google-rebuild-attestations/npm/@tanstack/vue-virtual/3.5.0/tanstack-vue-virtual-3.5.0.tgz/rebuild.intoto.jsonl"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			urls := subjectsToOssRebuildURLS(tt.subjects)
+			require.Equal(t, tt.expect, urls)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a repository collector for OSS Rebuild attestations. The collector only implements the `attestation.FetcherBySubject` interface and fetches when the subject has a purl in the resourcedescriptor uri.

Oh, and we only support npm for now. 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>