### PR TITLE
ossrebuild: Return nil atts on unhandled cases

### DIFF
--- a/repository/ossrebuild/ossrebuild.go
+++ b/repository/ossrebuild/ossrebuild.go
@@ -88,7 +88,9 @@ func subjectsToOssRebuildURLS(subjects []attestation.Subject) []string {
 // purl in the subject's URI
 func (c *Collector) FetchBySubject(ctx context.Context, fo attestation.FetchOptions, subjects []attestation.Subject) ([]attestation.Envelope, error) {
 	urls := subjectsToOssRebuildURLS(subjects)
-
+	if len(urls) == 0 {
+		return nil, nil
+	}
 	// Piggy back on the http collector to fetch
 	hcollector, err := http.New(http.WithURL(urls...))
 	if err != nil {


### PR DESCRIPTION
This fixes an edge case where the ossrebuild collector would err when trying to fetch unknown subjects 