### PR TITLE
Maven Updates

### DIFF
--- a/repository/maven/collector.go
+++ b/repository/maven/collector.go
@@ -204,32 +204,39 @@ func findSnapshotVersion(md *mavenMetadata, extension, classifier string) (snaps
 	return snapshotVersion{}, false
 }
 
-// fetchSignature looks for the main jar's .asc in the metadata,
-// fetches both the jar and its signature, and verifies using loaded keys.
-// Returns nil without error if the artifacts are not in the metadata or no keys are configured.
+// fetchSignature looks for the purl-identified artifact's .asc in the
+// metadata, fetches both the artifact and its signature, and verifies using
+// loaded keys. The artifact extension and classifier are taken from the
+// purl "type" and "classifier" qualifiers so the hashed subject matches
+// the artifact the purl refers to. Returns nil without error if the
+// artifacts are not in the metadata or no keys are configured.
 func (c *Collector) fetchSignature(agent *http.Agent, dirURL, artifactID string, md *mavenMetadata, opts attestation.FetchOptions) ([]attestation.Envelope, error) {
 	if len(c.Keys) == 0 {
 		return nil, nil
 	}
 
-	jarSV, jarOK := findSnapshotVersion(md, "jar", "")
-	ascSV, ascOK := findSnapshotVersion(md, "jar.asc", "")
-	if !jarOK || !ascOK {
+	artType := c.Options.artifactType()
+	classifier := c.Options.artifactClassifier()
+
+	artSV, artOK := findSnapshotVersion(md, artType, classifier)
+	ascSV, ascOK := findSnapshotVersion(md, artType+".asc", classifier)
+	if !artOK || !ascOK {
 		return nil, nil
 	}
 
-	// The jar and its signature must resolve to the same version to prevent
-	// replay attacks where an old valid signature is paired with a newer jar.
-	if jarSV.Value != ascSV.Value {
+	// The artifact and its signature must resolve to the same version to
+	// prevent replay attacks where an old valid signature is paired with
+	// a newer artifact.
+	if artSV.Value != ascSV.Value {
 		return nil, nil
 	}
 
-	jarFile := resolveFilename(artifactID, jarSV)
+	artFile := resolveFilename(artifactID, artSV)
 	ascFile := resolveFilename(artifactID, ascSV)
 	maxSize := readlimit.Resolve(opts.MaxReadSize)
 
-	// Fetch the jar and its signature in parallel.
-	urls := []string{dirURL + jarFile, dirURL + ascFile}
+	// Fetch the artifact and its signature in parallel.
+	urls := []string{dirURL + artFile, dirURL + ascFile}
 	datas, errs := agent.GetGroup(urls)
 
 	for i, e := range errs {
@@ -238,22 +245,22 @@ func (c *Collector) fetchSignature(agent *http.Agent, dirURL, artifactID string,
 		}
 	}
 
-	jarData, sigData := datas[0], datas[1]
+	artData, sigData := datas[0], datas[1]
 
-	if int64(len(jarData)) > maxSize {
-		return nil, fmt.Errorf("jar %s exceeds max read size (%d bytes)", jarFile, maxSize)
+	if int64(len(artData)) > maxSize {
+		return nil, fmt.Errorf("artifact %s exceeds max read size (%d bytes)", artFile, maxSize)
 	}
 
 	// Verify signature using loaded keys. Verification failure is not
 	// a fetch error — the signature simply didn't match any loaded key.
-	verification, verifyErr := verifyWithKeys(c.Keys, jarData, sigData)
+	verification, verifyErr := verifyWithKeys(c.Keys, artData, sigData)
 	if verifyErr != nil {
 		return nil, nil //nolint:nilerr // verification failure is not a fetch error
 	}
 
-	env, err := buildVirtualAttestation(jarFile, jarData, verification)
+	env, err := buildVirtualAttestation(artFile, artData, verification)
 	if err != nil {
-		return nil, fmt.Errorf("building signature attestation for %s: %w", jarFile, err)
+		return nil, fmt.Errorf("building signature attestation for %s: %w", artFile, err)
 	}
 
 	return []attestation.Envelope{env}, nil

--- a/repository/maven/collector_test.go
+++ b/repository/maven/collector_test.go
@@ -85,7 +85,7 @@ func TestWithBaseURL(t *testing.T) {
 }
 
 func TestBaseURLFromQualifier(t *testing.T) {
-	c, err := New(WithPackageURL("pkg:maven/com.example/foo@1.0.0?mavenbase=https://nexus.example.com/repo"))
+	c, err := New(WithPackageURL("pkg:maven/com.example/foo@1.0.0?repository_url=https://nexus.example.com/repo"))
 	require.NoError(t, err)
 	require.Equal(t, "https://nexus.example.com/repo", c.Options.BaseURL)
 	require.Equal(t,
@@ -96,7 +96,7 @@ func TestBaseURLFromQualifier(t *testing.T) {
 
 func TestBaseURLQualifierOverriddenByWithBaseURL(t *testing.T) {
 	c, err := New(
-		WithPackageURL("pkg:maven/com.example/foo@1.0.0?mavenbase=https://from-qualifier.com"),
+		WithPackageURL("pkg:maven/com.example/foo@1.0.0?repository_url=https://from-qualifier.com"),
 		WithBaseURL("https://explicit-override.com"),
 	)
 	require.NoError(t, err)

--- a/repository/maven/collector_test.go
+++ b/repository/maven/collector_test.go
@@ -55,6 +55,53 @@ func TestOptionsArtifactBaseName(t *testing.T) {
 	require.Equal(t, "alibabacloud-ga20191120-3.0.1", c.Options.artifactBaseName())
 }
 
+func TestArtifactTypeAndClassifier(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		purl           string
+		wantType       string
+		wantClassifier string
+	}{
+		{
+			name:           "defaults",
+			purl:           "pkg:maven/com.example/foo@1.0.0",
+			wantType:       "jar",
+			wantClassifier: "",
+		},
+		{
+			name:           "type war",
+			purl:           "pkg:maven/com.example/foo@1.0.0?type=war",
+			wantType:       "war",
+			wantClassifier: "",
+		},
+		{
+			name:           "classifier sources",
+			purl:           "pkg:maven/com.example/foo@1.0.0?classifier=sources",
+			wantType:       "jar",
+			wantClassifier: "sources",
+		},
+		{
+			name:           "type and classifier",
+			purl:           "pkg:maven/com.example/foo@1.0.0?type=jar&classifier=javadoc",
+			wantType:       "jar",
+			wantClassifier: "javadoc",
+		},
+		{
+			name:           "empty type falls back to jar",
+			purl:           "pkg:maven/com.example/foo@1.0.0?type=",
+			wantType:       "jar",
+			wantClassifier: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := New(WithPackageURL(tc.purl))
+			require.NoError(t, err)
+			require.Equal(t, tc.wantType, c.Options.artifactType())
+			require.Equal(t, tc.wantClassifier, c.Options.artifactClassifier())
+		})
+	}
+}
+
 func TestNewValidation(t *testing.T) {
 	// Missing purl
 	_, err := New()

--- a/repository/maven/options.go
+++ b/repository/maven/options.go
@@ -43,8 +43,8 @@ func WithPackageURL(purlStr string) optFn {
 		}
 		c.Options.PackageURL = purl
 
-		// Check for a mavenbase qualifier to override the base URL.
-		if baseURL, ok := purl.Qualifiers.Map()["mavenbase"]; ok && baseURL != "" {
+		// Check for a repository_url qualifier to override the base URL.
+		if baseURL, ok := purl.Qualifiers.Map()["repository_url"]; ok && baseURL != "" {
 			c.Options.BaseURL = strings.TrimRight(baseURL, "/")
 		}
 

--- a/repository/maven/options.go
+++ b/repository/maven/options.go
@@ -87,3 +87,18 @@ func (o *Options) directoryURL() string {
 func (o *Options) artifactBaseName() string {
 	return fmt.Sprintf("%s-%s", o.PackageURL.Name, o.PackageURL.Version)
 }
+
+// artifactType returns the Maven packaging type from the purl "type"
+// qualifier. Per the purl-spec, it defaults to "jar" when absent.
+func (o *Options) artifactType() string {
+	if t, ok := o.PackageURL.Qualifiers.Map()["type"]; ok && t != "" {
+		return t
+	}
+	return "jar"
+}
+
+// artifactClassifier returns the Maven classifier from the purl
+// "classifier" qualifier, or the empty string when absent.
+func (o *Options) artifactClassifier() string {
+	return o.PackageURL.Qualifiers.Map()["classifier"]
+}


### PR DESCRIPTION
This pull request enhances the flexibility and correctness of Maven artifact signature verification by allowing the artifact type and classifier to be specified via purl qualifiers, rather than being hardcoded to "jar". It also standardizes the use of the `repository_url` qualifier for overriding the repository base URL, replacing the previous `mavenbase` qualifier. Comprehensive tests have been added to ensure these behaviors.

**Artifact type and classifier handling:**
* The `fetchSignature` method now uses the artifact type and classifier from the purl qualifiers, ensuring that signature verification matches the specific artifact referenced by the purl, not just the main jar. [[1]](diffhunk://#diff-636ce8012a482cc40cf2c07e5b512cf07678d00069dfe5686860b7fe4fbf51c4L207-R239) [[2]](diffhunk://#diff-636ce8012a482cc40cf2c07e5b512cf07678d00069dfe5686860b7fe4fbf51c4L241-R263)
* Added `artifactType` and `artifactClassifier` methods to the `Options` struct to extract the type and classifier from the purl, defaulting to "jar" and empty string respectively.
* Added tests to verify correct extraction of artifact type and classifier from various purl formats.

**Repository base URL override:**
* Changed the qualifier for overriding the Maven repository base URL from `mavenbase` to `repository_url` for consistency with purl conventions, and updated all relevant code and tests. [[1]](diffhunk://#diff-bad4fa8143f39bc127be50e1af7e741c6b391bf3a4b14f9571829e7a9dbd19c0L46-R47) [[2]](diffhunk://#diff-6f21b59746bca656396498f158971c8fe377cc0c9abad82567b529202d9c78f5L88-R135) [[3]](diffhunk://#diff-6f21b59746bca656396498f158971c8fe377cc0c9abad82567b529202d9c78f5L99-R146)

These changes improve the accuracy and configurability of artifact resolution and signature verification in the Maven collector.