### PR TITLE
Maven collector driver global mode

### DIFF
--- a/repository/maven/collector.go
+++ b/repository/maven/collector.go
@@ -79,13 +79,18 @@ func (c *Collector) Fetch(_ context.Context, opts attestation.FetchOptions) ([]a
 	if !c.Options.HasPackageURL() {
 		return nil, nil
 	}
-	return c.fetchForPurl(opts, &c.Options.PackageURL)
+	// In configured mode the collector's BaseURL is authoritative — it
+	// already reflects any "repository_url" qualifier captured at
+	// construction time and preserves explicit WithBaseURL overrides.
+	return c.fetchForPurl(opts, &c.Options.PackageURL, c.Options.BaseURL)
 }
 
-// fetchForPurl runs the full attestation lookup for a single Maven purl:
-// maven-metadata.xml, signature, JSONL bundle, and any unsigned SBOMs.
-func (c *Collector) fetchForPurl(opts attestation.FetchOptions, purl *gopurl.PackageURL) ([]attestation.Envelope, error) {
-	baseURL := baseURLForPurl(purl, c.Options.BaseURL)
+// fetchForPurl runs the full attestation lookup for a single Maven purl
+// against the supplied base URL. Callers own the base-URL policy:
+// configured mode passes the collector's BaseURL as-is; global mode
+// resolves per-subject via baseURLForPurl so a "repository_url"
+// qualifier on a subject purl can target its own repository.
+func (c *Collector) fetchForPurl(opts attestation.FetchOptions, purl *gopurl.PackageURL, baseURL string) ([]attestation.Envelope, error) {
 	dirURL := directoryURL(purl, baseURL)
 	artifactID := purl.Name
 	agent := http.NewAgent().WithFailOnHTTPError(true)
@@ -142,8 +147,12 @@ func (c *Collector) FetchBySubject(ctx context.Context, opts attestation.FetchOp
 		all = envs
 	} else {
 		purls := extractMavenPurls(subj)
-		for _, p := range purls {
-			envs, err := c.fetchForPurl(opts, p)
+		for i := range purls {
+			p := &purls[i]
+			// Global mode: a per-subject purl can carry its own
+			// "repository_url" qualifier; fall back to the collector's
+			// BaseURL when it doesn't.
+			envs, err := c.fetchForPurl(opts, p, baseURLForPurl(p, c.Options.BaseURL))
 			if err != nil {
 				// A missing or unreachable package for one subject shouldn't
 				// fail the whole query — log and continue.
@@ -188,10 +197,11 @@ func (c *Collector) FetchByPredicateType(ctx context.Context, opts attestation.F
 
 // extractMavenPurls reads Maven package URLs from the Uri and Name fields
 // of the provided subjects. Non-Maven or unparseable purls are ignored,
-// and duplicates are deduplicated.
-func extractMavenPurls(subjects []attestation.Subject) []*gopurl.PackageURL {
+// and duplicates are deduplicated. The slice owns its elements — callers
+// that need a pointer should address into the slice (&purls[i]).
+func extractMavenPurls(subjects []attestation.Subject) []gopurl.PackageURL {
 	seen := map[string]struct{}{}
-	var ret []*gopurl.PackageURL
+	var ret []gopurl.PackageURL
 	for _, s := range subjects {
 		for _, candidate := range []string{s.GetUri(), s.GetName()} {
 			if !strings.HasPrefix(candidate, "pkg:") {
@@ -209,7 +219,7 @@ func extractMavenPurls(subjects []attestation.Subject) []*gopurl.PackageURL {
 				continue
 			}
 			seen[id] = struct{}{}
-			ret = append(ret, &p)
+			ret = append(ret, p)
 		}
 	}
 	return ret

--- a/repository/maven/collector.go
+++ b/repository/maven/collector.go
@@ -12,11 +12,14 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/carabiner-dev/attestation"
 	"github.com/carabiner-dev/hasher"
 	sapi "github.com/carabiner-dev/signer/api/v1"
 	"github.com/carabiner-dev/signer/key"
+	gopurl "github.com/package-url/packageurl-go"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"sigs.k8s.io/release-utils/http"
 
@@ -69,15 +72,24 @@ func (c *Collector) SetKeys(keys []key.PublicKeyProvider) {
 	c.Keys = keys
 }
 
-// Fetch retrieves attestations from the Maven repository directory.
-// It fetches maven-metadata.xml to resolve artifact filenames, then
-// looks for signatures, JSONL attestation bundles, and unsigned SBOMs.
+// Fetch retrieves attestations for the configured package URL. When the
+// collector is in global mode (no package URL configured) it returns
+// nothing — global mode is subject-driven, use FetchBySubject instead.
 func (c *Collector) Fetch(_ context.Context, opts attestation.FetchOptions) ([]attestation.Envelope, error) {
-	dirURL := c.Options.directoryURL()
-	artifactID := c.Options.PackageURL.Name
+	if !c.Options.HasPackageURL() {
+		return nil, nil
+	}
+	return c.fetchForPurl(opts, c.Options.PackageURL)
+}
+
+// fetchForPurl runs the full attestation lookup for a single Maven purl:
+// maven-metadata.xml, signature, JSONL bundle, and any unsigned SBOMs.
+func (c *Collector) fetchForPurl(opts attestation.FetchOptions, purl gopurl.PackageURL) ([]attestation.Envelope, error) {
+	baseURL := baseURLForPurl(purl, c.Options.BaseURL)
+	dirURL := directoryURL(purl, baseURL)
+	artifactID := purl.Name
 	agent := http.NewAgent().WithFailOnHTTPError(true)
 
-	// Fetch and parse maven-metadata.xml to resolve artifact filenames.
 	md, err := c.fetchMetadata(agent, dirURL)
 	if err != nil {
 		return nil, err
@@ -85,21 +97,18 @@ func (c *Collector) Fetch(_ context.Context, opts attestation.FetchOptions) ([]a
 
 	var ret []attestation.Envelope
 
-	// 1. Look for the main jar's .asc signature.
-	ascEnvs, err := c.fetchSignature(agent, dirURL, artifactID, md, opts)
+	ascEnvs, err := c.fetchSignature(agent, dirURL, purl, md, opts)
 	if err != nil {
 		return nil, err
 	}
 	ret = append(ret, ascEnvs...)
 
-	// 2. Look for JSONL attestation bundles (intoto.jsonl extension).
 	jsonlEnvs, err := c.fetchJSONLAttestations(agent, dirURL, artifactID, md, opts)
 	if err != nil {
 		return nil, err
 	}
 	ret = append(ret, jsonlEnvs...)
 
-	// 3. Look for unsigned SBOMs (spdx.json, cdx.json, cyclonedx json/xml).
 	sbomEnvs, err := c.fetchSBOMs(agent, dirURL, artifactID, md, opts)
 	if err != nil {
 		return nil, err
@@ -117,11 +126,32 @@ func (c *Collector) Fetch(_ context.Context, opts attestation.FetchOptions) ([]a
 	return ret, nil
 }
 
-// FetchBySubject handles collecting by subject hash.
+// FetchBySubject collects attestations for each subject. In configured
+// mode it fetches once for the configured purl and filters by subject
+// digest. In global mode it extracts Maven purls from subjects (via the
+// Uri or Name field of the resource descriptor), fetches for each, and
+// filters the union by the requested digests.
 func (c *Collector) FetchBySubject(ctx context.Context, opts attestation.FetchOptions, subj []attestation.Subject) ([]attestation.Envelope, error) {
-	all, err := c.Fetch(ctx, opts)
-	if err != nil {
-		return nil, err
+	var all []attestation.Envelope
+
+	if c.Options.HasPackageURL() {
+		envs, err := c.Fetch(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		all = envs
+	} else {
+		purls := extractMavenPurls(subj)
+		for _, p := range purls {
+			envs, err := c.fetchForPurl(opts, p)
+			if err != nil {
+				// A missing or unreachable package for one subject shouldn't
+				// fail the whole query — log and continue.
+				logrus.Debugf("maven: skipping %s: %v", p.String(), err)
+				continue
+			}
+			all = append(all, envs...)
+		}
 	}
 
 	m := make([]map[string]string, 0, len(subj))
@@ -134,8 +164,13 @@ func (c *Collector) FetchBySubject(ctx context.Context, opts attestation.FetchOp
 	}).Run(all), nil
 }
 
-// FetchByPredicateType handles collecting by predicate type.
+// FetchByPredicateType handles collecting by predicate type. It requires
+// a configured package URL — global mode is subject-driven and has no
+// per-predicate-type entry point.
 func (c *Collector) FetchByPredicateType(ctx context.Context, opts attestation.FetchOptions, pts []attestation.PredicateType) ([]attestation.Envelope, error) {
+	if !c.Options.HasPackageURL() {
+		return nil, nil
+	}
 	all, err := c.Fetch(ctx, opts)
 	if err != nil {
 		return nil, err
@@ -149,6 +184,35 @@ func (c *Collector) FetchByPredicateType(ctx context.Context, opts attestation.F
 	return attestation.NewQuery().WithFilter(&filters.PredicateTypeMatcher{
 		PredicateTypes: m,
 	}).Run(all), nil
+}
+
+// extractMavenPurls reads Maven package URLs from the Uri and Name fields
+// of the provided subjects. Non-Maven or unparseable purls are ignored,
+// and duplicates are deduplicated.
+func extractMavenPurls(subjects []attestation.Subject) []gopurl.PackageURL {
+	seen := map[string]struct{}{}
+	var ret []gopurl.PackageURL
+	for _, s := range subjects {
+		for _, candidate := range []string{s.GetUri(), s.GetName()} {
+			if !strings.HasPrefix(candidate, "pkg:") {
+				continue
+			}
+			p, err := gopurl.FromString(candidate)
+			if err != nil {
+				continue
+			}
+			if err := validateMavenPurl(p); err != nil {
+				continue
+			}
+			key := p.String()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			ret = append(ret, p)
+		}
+	}
+	return ret
 }
 
 // mavenMetadata represents the relevant parts of maven-metadata.xml.
@@ -210,13 +274,14 @@ func findSnapshotVersion(md *mavenMetadata, extension, classifier string) (snaps
 // purl "type" and "classifier" qualifiers so the hashed subject matches
 // the artifact the purl refers to. Returns nil without error if the
 // artifacts are not in the metadata or no keys are configured.
-func (c *Collector) fetchSignature(agent *http.Agent, dirURL, artifactID string, md *mavenMetadata, opts attestation.FetchOptions) ([]attestation.Envelope, error) {
+func (c *Collector) fetchSignature(agent *http.Agent, dirURL string, purl gopurl.PackageURL, md *mavenMetadata, opts attestation.FetchOptions) ([]attestation.Envelope, error) {
 	if len(c.Keys) == 0 {
 		return nil, nil
 	}
 
-	artType := c.Options.artifactType()
-	classifier := c.Options.artifactClassifier()
+	artifactID := purl.Name
+	artType := artifactType(purl)
+	classifier := artifactClassifier(purl)
 
 	artSV, artOK := findSnapshotVersion(md, artType, classifier)
 	ascSV, ascOK := findSnapshotVersion(md, artType+".asc", classifier)

--- a/repository/maven/collector.go
+++ b/repository/maven/collector.go
@@ -79,12 +79,12 @@ func (c *Collector) Fetch(_ context.Context, opts attestation.FetchOptions) ([]a
 	if !c.Options.HasPackageURL() {
 		return nil, nil
 	}
-	return c.fetchForPurl(opts, c.Options.PackageURL)
+	return c.fetchForPurl(opts, &c.Options.PackageURL)
 }
 
 // fetchForPurl runs the full attestation lookup for a single Maven purl:
 // maven-metadata.xml, signature, JSONL bundle, and any unsigned SBOMs.
-func (c *Collector) fetchForPurl(opts attestation.FetchOptions, purl gopurl.PackageURL) ([]attestation.Envelope, error) {
+func (c *Collector) fetchForPurl(opts attestation.FetchOptions, purl *gopurl.PackageURL) ([]attestation.Envelope, error) {
 	baseURL := baseURLForPurl(purl, c.Options.BaseURL)
 	dirURL := directoryURL(purl, baseURL)
 	artifactID := purl.Name
@@ -189,9 +189,9 @@ func (c *Collector) FetchByPredicateType(ctx context.Context, opts attestation.F
 // extractMavenPurls reads Maven package URLs from the Uri and Name fields
 // of the provided subjects. Non-Maven or unparseable purls are ignored,
 // and duplicates are deduplicated.
-func extractMavenPurls(subjects []attestation.Subject) []gopurl.PackageURL {
+func extractMavenPurls(subjects []attestation.Subject) []*gopurl.PackageURL {
 	seen := map[string]struct{}{}
-	var ret []gopurl.PackageURL
+	var ret []*gopurl.PackageURL
 	for _, s := range subjects {
 		for _, candidate := range []string{s.GetUri(), s.GetName()} {
 			if !strings.HasPrefix(candidate, "pkg:") {
@@ -201,15 +201,15 @@ func extractMavenPurls(subjects []attestation.Subject) []gopurl.PackageURL {
 			if err != nil {
 				continue
 			}
-			if err := validateMavenPurl(p); err != nil {
+			if err := validateMavenPurl(&p); err != nil {
 				continue
 			}
-			key := p.String()
-			if _, ok := seen[key]; ok {
+			id := p.String()
+			if _, ok := seen[id]; ok {
 				continue
 			}
-			seen[key] = struct{}{}
-			ret = append(ret, p)
+			seen[id] = struct{}{}
+			ret = append(ret, &p)
 		}
 	}
 	return ret
@@ -274,7 +274,7 @@ func findSnapshotVersion(md *mavenMetadata, extension, classifier string) (snaps
 // purl "type" and "classifier" qualifiers so the hashed subject matches
 // the artifact the purl refers to. Returns nil without error if the
 // artifacts are not in the metadata or no keys are configured.
-func (c *Collector) fetchSignature(agent *http.Agent, dirURL string, purl gopurl.PackageURL, md *mavenMetadata, opts attestation.FetchOptions) ([]attestation.Envelope, error) {
+func (c *Collector) fetchSignature(agent *http.Agent, dirURL string, purl *gopurl.PackageURL, md *mavenMetadata, opts attestation.FetchOptions) ([]attestation.Envelope, error) {
 	if len(c.Keys) == 0 {
 		return nil, nil
 	}

--- a/repository/maven/collector_test.go
+++ b/repository/maven/collector_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/carabiner-dev/attestation"
+	gopurl "github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -156,6 +157,29 @@ func TestBaseURLQualifierOverriddenByWithBaseURL(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, "https://explicit-override.com", c.Options.BaseURL)
+
+	// Verify the explicit BaseURL also wins at fetch time (configured mode
+	// treats c.Options.BaseURL as authoritative and does not re-read the
+	// purl's repository_url qualifier).
+	require.Equal(t,
+		"https://explicit-override.com/com/example/foo/1.0.0/",
+		directoryURL(&c.Options.PackageURL, c.Options.BaseURL),
+	)
+}
+
+func TestGlobalModeHonorsSubjectRepositoryURLQualifier(t *testing.T) {
+	c, err := New() // global mode: no package URL configured
+	require.NoError(t, err)
+
+	// A per-subject purl with repository_url should target its own repo.
+	p, err := gopurl.FromString("pkg:maven/com.example/foo@1.0.0?repository_url=https://from-subject.com")
+	require.NoError(t, err)
+	require.Equal(t, "https://from-subject.com", baseURLForPurl(&p, c.Options.BaseURL))
+
+	// Without the qualifier, the collector's BaseURL is used as fallback.
+	plain, err := gopurl.FromString("pkg:maven/com.example/bar@2.0.0")
+	require.NoError(t, err)
+	require.Equal(t, defaultBaseURL, baseURLForPurl(&plain, c.Options.BaseURL))
 }
 
 func TestBuildFactory(t *testing.T) {

--- a/repository/maven/collector_test.go
+++ b/repository/maven/collector_test.go
@@ -6,6 +6,7 @@ package maven
 import (
 	"testing"
 
+	"github.com/carabiner-dev/attestation"
 	"github.com/stretchr/testify/require"
 )
 
@@ -103,9 +104,15 @@ func TestArtifactTypeAndClassifier(t *testing.T) {
 }
 
 func TestNewValidation(t *testing.T) {
-	// Missing purl
-	_, err := New()
-	require.Error(t, err)
+	// No purl — global mode is valid.
+	c, err := New()
+	require.NoError(t, err)
+	require.False(t, c.Options.HasPackageURL())
+
+	// Explicit empty purl — also global mode.
+	c, err = New(WithPackageURL(""))
+	require.NoError(t, err)
+	require.False(t, c.Options.HasPackageURL())
 
 	// Non-maven purl
 	_, err = New(WithPackageURL("pkg:npm/foo@1.0.0"))
@@ -116,9 +123,10 @@ func TestNewValidation(t *testing.T) {
 	require.Error(t, err)
 
 	// Valid
-	c, err := New(WithPackageURL("pkg:maven/com.example/foo@1.0.0"))
+	c, err = New(WithPackageURL("pkg:maven/com.example/foo@1.0.0"))
 	require.NoError(t, err)
 	require.Equal(t, defaultBaseURL, c.Options.BaseURL)
+	require.True(t, c.Options.HasPackageURL())
 }
 
 func TestWithBaseURL(t *testing.T) {
@@ -160,6 +168,53 @@ func TestBuildFactory(t *testing.T) {
 	require.Equal(t, "com.example", c.Options.PackageURL.Namespace)
 	require.Equal(t, "foo", c.Options.PackageURL.Name)
 	require.Equal(t, "1.0.0", c.Options.PackageURL.Version)
+}
+
+func TestBuildFactoryGlobalMode(t *testing.T) {
+	// An empty init string (e.g. "maven:") yields a global-mode collector
+	// with no configured package URL.
+	repo, err := Build("")
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+
+	c, ok := repo.(*Collector)
+	require.True(t, ok)
+	require.False(t, c.Options.HasPackageURL())
+	require.Equal(t, defaultBaseURL, c.Options.BaseURL)
+}
+
+// fakeSubject satisfies attestation.Subject for unit tests.
+type fakeSubject struct {
+	name, uri string
+	digest    map[string]string
+}
+
+func (fs *fakeSubject) GetName() string              { return fs.name }
+func (fs *fakeSubject) GetUri() string               { return fs.uri }
+func (fs *fakeSubject) GetDigest() map[string]string { return fs.digest }
+
+func TestExtractMavenPurls(t *testing.T) {
+	subjects := []attestation.Subject{
+		// Maven purl in Uri.
+		&fakeSubject{uri: "pkg:maven/com.example/foo@1.0.0"},
+		// Maven purl in Name.
+		&fakeSubject{name: "pkg:maven/com.example/bar@2.0.0"},
+		// Non-maven purl — ignored.
+		&fakeSubject{uri: "pkg:npm/lodash@4.0.0"},
+		// Unparseable — ignored.
+		&fakeSubject{uri: "not-a-purl"},
+		// Duplicate of the first — deduped.
+		&fakeSubject{uri: "pkg:maven/com.example/foo@1.0.0"},
+		// Incomplete maven purl (no version) — ignored.
+		&fakeSubject{uri: "pkg:maven/com.example/baz"},
+	}
+
+	got := extractMavenPurls(subjects)
+	require.Len(t, got, 2)
+
+	names := []string{got[0].Name, got[1].Name}
+	require.Contains(t, names, "foo")
+	require.Contains(t, names, "bar")
 }
 
 func TestResolveFilename(t *testing.T) {

--- a/repository/maven/options.go
+++ b/repository/maven/options.go
@@ -28,18 +28,20 @@ type Options struct {
 	PackageURL gopurl.PackageURL
 }
 
-// WithPackageURL sets the package URL from a purl string.
+// WithPackageURL sets the package URL from a purl string. An empty string
+// is accepted and leaves the collector in "global" mode — no package is
+// configured up-front and FetchBySubject will resolve a purl per subject.
 func WithPackageURL(purlStr string) optFn {
 	return func(c *Collector) error {
+		if purlStr == "" {
+			return nil
+		}
 		purl, err := gopurl.FromString(purlStr)
 		if err != nil {
 			return fmt.Errorf("parsing package URL: %w", err)
 		}
-		if purl.Type != "maven" {
-			return fmt.Errorf("unsupported package type %q, expected maven", purl.Type)
-		}
-		if purl.Namespace == "" || purl.Name == "" || purl.Version == "" {
-			return fmt.Errorf("maven purl must include namespace, name, and version")
+		if err := validateMavenPurl(purl); err != nil {
+			return err
 		}
 		c.Options.PackageURL = purl
 
@@ -60,45 +62,76 @@ func WithBaseURL(url string) optFn {
 	}
 }
 
-// Validate checks that the options are complete.
+// Validate checks that the options are complete. A package URL is optional
+// at configuration time: without one the collector runs in global mode,
+// resolving the purl per subject in FetchBySubject.
 func (o *Options) Validate() error {
 	if o.BaseURL == "" {
 		return errors.New("no base URL set")
 	}
-	if o.PackageURL.Name == "" {
-		return errors.New("no package URL set")
+	return nil
+}
+
+// HasPackageURL reports whether a package URL has been configured on the
+// collector (i.e. it is not running in global mode).
+func (o *Options) HasPackageURL() bool {
+	return o.PackageURL.Name != ""
+}
+
+// validateMavenPurl ensures a parsed purl is a well-formed Maven purl.
+func validateMavenPurl(purl gopurl.PackageURL) error {
+	if purl.Type != "maven" {
+		return fmt.Errorf("unsupported package type %q, expected maven", purl.Type)
+	}
+	if purl.Namespace == "" || purl.Name == "" || purl.Version == "" {
+		return fmt.Errorf("maven purl must include namespace, name, and version")
 	}
 	return nil
 }
 
-// directoryURL returns the Maven repository directory URL for the artifact.
+// baseURLForPurl picks the base Maven repository URL for a purl. A
+// "repository_url" qualifier on the purl wins; otherwise the provided
+// fallback is returned.
+func baseURLForPurl(purl gopurl.PackageURL, fallback string) string {
+	if v, ok := purl.Qualifiers.Map()["repository_url"]; ok && v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return fallback
+}
+
+// directoryURL returns the Maven repository directory URL for a purl.
 // For example, pkg:maven/com.aliyun/alibabacloud-ga20191120@3.0.1 becomes:
 // https://repo.maven.apache.org/maven2/com/aliyun/alibabacloud-ga20191120/3.0.1/
-func (o *Options) directoryURL() string {
-	// Convert namespace dots to path separators.
-	namespacePath := strings.ReplaceAll(o.PackageURL.Namespace, ".", "/")
+func directoryURL(purl gopurl.PackageURL, baseURL string) string {
+	namespacePath := strings.ReplaceAll(purl.Namespace, ".", "/")
 	return fmt.Sprintf("%s/%s/%s/%s/",
-		o.BaseURL, namespacePath, o.PackageURL.Name, o.PackageURL.Version,
+		strings.TrimRight(baseURL, "/"), namespacePath, purl.Name, purl.Version,
 	)
 }
 
-// artifactBaseName returns the base name for the main artifact.
-// For example: alibabacloud-ga20191120-3.0.1
-func (o *Options) artifactBaseName() string {
-	return fmt.Sprintf("%s-%s", o.PackageURL.Name, o.PackageURL.Version)
-}
-
-// artifactType returns the Maven packaging type from the purl "type"
-// qualifier. Per the purl-spec, it defaults to "jar" when absent.
-func (o *Options) artifactType() string {
-	if t, ok := o.PackageURL.Qualifiers.Map()["type"]; ok && t != "" {
+// artifactType returns the Maven packaging type from a purl's "type"
+// qualifier, defaulting to "jar" per the purl-spec.
+func artifactType(purl gopurl.PackageURL) string {
+	if t, ok := purl.Qualifiers.Map()["type"]; ok && t != "" {
 		return t
 	}
 	return "jar"
 }
 
-// artifactClassifier returns the Maven classifier from the purl
-// "classifier" qualifier, or the empty string when absent.
+// artifactClassifier returns the "classifier" qualifier from a purl, or
+// the empty string when absent.
+func artifactClassifier(purl gopurl.PackageURL) string {
+	return purl.Qualifiers.Map()["classifier"]
+}
+
+// Thin Options wrappers kept for backward compatibility with existing tests
+// that use the configured PackageURL.
+func (o *Options) directoryURL() string { return directoryURL(o.PackageURL, o.BaseURL) }
+func (o *Options) artifactType() string { return artifactType(o.PackageURL) }
 func (o *Options) artifactClassifier() string {
-	return o.PackageURL.Qualifiers.Map()["classifier"]
+	return artifactClassifier(o.PackageURL)
+}
+
+func (o *Options) artifactBaseName() string {
+	return fmt.Sprintf("%s-%s", o.PackageURL.Name, o.PackageURL.Version)
 }

--- a/repository/maven/options.go
+++ b/repository/maven/options.go
@@ -40,7 +40,7 @@ func WithPackageURL(purlStr string) optFn {
 		if err != nil {
 			return fmt.Errorf("parsing package URL: %w", err)
 		}
-		if err := validateMavenPurl(purl); err != nil {
+		if err := validateMavenPurl(&purl); err != nil {
 			return err
 		}
 		c.Options.PackageURL = purl
@@ -79,7 +79,7 @@ func (o *Options) HasPackageURL() bool {
 }
 
 // validateMavenPurl ensures a parsed purl is a well-formed Maven purl.
-func validateMavenPurl(purl gopurl.PackageURL) error {
+func validateMavenPurl(purl *gopurl.PackageURL) error {
 	if purl.Type != "maven" {
 		return fmt.Errorf("unsupported package type %q, expected maven", purl.Type)
 	}
@@ -92,7 +92,7 @@ func validateMavenPurl(purl gopurl.PackageURL) error {
 // baseURLForPurl picks the base Maven repository URL for a purl. A
 // "repository_url" qualifier on the purl wins; otherwise the provided
 // fallback is returned.
-func baseURLForPurl(purl gopurl.PackageURL, fallback string) string {
+func baseURLForPurl(purl *gopurl.PackageURL, fallback string) string {
 	if v, ok := purl.Qualifiers.Map()["repository_url"]; ok && v != "" {
 		return strings.TrimRight(v, "/")
 	}
@@ -102,7 +102,7 @@ func baseURLForPurl(purl gopurl.PackageURL, fallback string) string {
 // directoryURL returns the Maven repository directory URL for a purl.
 // For example, pkg:maven/com.aliyun/alibabacloud-ga20191120@3.0.1 becomes:
 // https://repo.maven.apache.org/maven2/com/aliyun/alibabacloud-ga20191120/3.0.1/
-func directoryURL(purl gopurl.PackageURL, baseURL string) string {
+func directoryURL(purl *gopurl.PackageURL, baseURL string) string {
 	namespacePath := strings.ReplaceAll(purl.Namespace, ".", "/")
 	return fmt.Sprintf("%s/%s/%s/%s/",
 		strings.TrimRight(baseURL, "/"), namespacePath, purl.Name, purl.Version,
@@ -111,7 +111,7 @@ func directoryURL(purl gopurl.PackageURL, baseURL string) string {
 
 // artifactType returns the Maven packaging type from a purl's "type"
 // qualifier, defaulting to "jar" per the purl-spec.
-func artifactType(purl gopurl.PackageURL) string {
+func artifactType(purl *gopurl.PackageURL) string {
 	if t, ok := purl.Qualifiers.Map()["type"]; ok && t != "" {
 		return t
 	}
@@ -120,16 +120,16 @@ func artifactType(purl gopurl.PackageURL) string {
 
 // artifactClassifier returns the "classifier" qualifier from a purl, or
 // the empty string when absent.
-func artifactClassifier(purl gopurl.PackageURL) string {
+func artifactClassifier(purl *gopurl.PackageURL) string {
 	return purl.Qualifiers.Map()["classifier"]
 }
 
 // Thin Options wrappers kept for backward compatibility with existing tests
 // that use the configured PackageURL.
-func (o *Options) directoryURL() string { return directoryURL(o.PackageURL, o.BaseURL) }
-func (o *Options) artifactType() string { return artifactType(o.PackageURL) }
+func (o *Options) directoryURL() string { return directoryURL(&o.PackageURL, o.BaseURL) }
+func (o *Options) artifactType() string { return artifactType(&o.PackageURL) }
 func (o *Options) artifactClassifier() string {
-	return artifactClassifier(o.PackageURL)
+	return artifactClassifier(&o.PackageURL)
 }
 
 func (o *Options) artifactBaseName() string {


### PR DESCRIPTION
This pull request refactors the Maven repository collector to support a new "global mode" where no package URL is configured up-front. In this mode, the collector can resolve Maven package URLs dynamically from the provided subjects, allowing for more flexible and subject-driven attestation collection. The changes also improve validation, error handling, and test coverage for this new behavior.

Key changes include:

**Global Mode and Collector Behavior:**
- Refactored the collector to allow operation without a configured package URL ("global mode"), enabling attestation fetching based on subjects' Maven package URLs. Methods like `Fetch`, `FetchBySubject`, and `FetchByPredicateType` have been updated to handle both configured and global modes appropriately. [[1]](diffhunk://#diff-636ce8012a482cc40cf2c07e5b512cf07678d00069dfe5686860b7fe4fbf51c4L72-L102) [[2]](diffhunk://#diff-636ce8012a482cc40cf2c07e5b512cf07678d00069dfe5686860b7fe4fbf51c4L120-R155) [[3]](diffhunk://#diff-636ce8012a482cc40cf2c07e5b512cf07678d00069dfe5686860b7fe4fbf51c4L137-R173) [[4]](diffhunk://#diff-bad4fa8143f39bc127be50e1af7e741c6b391bf3a4b14f9571829e7a9dbd19c0L31-R44) [[5]](diffhunk://#diff-bad4fa8143f39bc127be50e1af7e741c6b391bf3a4b14f9571829e7a9dbd19c0L63-R136)

**Maven PURL Extraction and Validation:**
- Added `extractMavenPurls`, a helper that extracts and deduplicates valid Maven package URLs from the `Uri` and `Name` fields of attestation subjects, ignoring non-Maven or malformed entries. Improved validation logic for Maven PURLs. [[1]](diffhunk://#diff-636ce8012a482cc40cf2c07e5b512cf07678d00069dfe5686860b7fe4fbf51c4R189-R217) [[2]](diffhunk://#diff-bad4fa8143f39bc127be50e1af7e741c6b391bf3a4b14f9571829e7a9dbd19c0L63-R136)

**Options and Utility Refactoring:**
- Refactored utility functions to operate on arbitrary Maven PURLs, not just the configured one. Introduced helpers like `baseURLForPurl`, `directoryURL`, `artifactType`, and `artifactClassifier` for improved flexibility and backwards compatibility.

**Signature Fetching Improvements:**
- Updated the signature fetching logic to use the PURL from the subject (when in global mode) instead of always relying on the configured option.

**Testing Enhancements:**
- Expanded unit tests to cover global mode, PURL extraction, and validation, ensuring correct handling of both configured and dynamic subject-driven scenarios. [[1]](diffhunk://#diff-6f21b59746bca656396498f158971c8fe377cc0c9abad82567b529202d9c78f5L106-R115) [[2]](diffhunk://#diff-6f21b59746bca656396498f158971c8fe377cc0c9abad82567b529202d9c78f5L119-R129) [[3]](diffhunk://#diff-6f21b59746bca656396498f158971c8fe377cc0c9abad82567b529202d9c78f5R173-R219)