### PR TITLE
Add signed artifact <> envelope bridge

### DIFF
--- a/envelope/envelope.go
+++ b/envelope/envelope.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/carabiner-dev/attestation"
 	"github.com/carabiner-dev/hasher"
+	"github.com/carabiner-dev/signer"
 	"github.com/sirupsen/logrus"
 
 	"github.com/carabiner-dev/collector/envelope/bare"
@@ -92,4 +93,37 @@ func (list *ParserList) Parse(r io.Reader) ([]attestation.Envelope, error) {
 	}
 
 	return nil, attestation.ErrNotCorrectFormat
+}
+
+// FromSignedArtifact returns an attestation.Envelope from a SignedArtifact
+// object as returned from the signer. It serializes the artifact to its
+// canonical JSON form and parses it through the matching collector parser.
+func FromSignedArtifact(artifact signer.SignedArtifact) (attestation.Envelope, error) {
+	if artifact == nil {
+		return nil, errors.New("signed artifact is nil")
+	}
+
+	var parser attestation.EnvelopeParser
+	switch artifact.Kind() {
+	case signer.ArtifactKindBundle:
+		parser = &bundle.Parser{}
+	case signer.ArtifactKindEnvelope:
+		parser = &dsse.Parser{}
+	default:
+		return nil, fmt.Errorf("unsupported signed artifact kind %q", artifact.Kind())
+	}
+
+	var buf bytes.Buffer
+	if _, err := artifact.WriteTo(&buf); err != nil {
+		return nil, fmt.Errorf("serializing signed artifact: %w", err)
+	}
+
+	envs, err := parser.ParseStream(&buf)
+	if err != nil {
+		return nil, fmt.Errorf("parsing signed artifact as %s: %w", artifact.Kind(), err)
+	}
+	if len(envs) == 0 {
+		return nil, fmt.Errorf("parser returned no envelopes for %s artifact", artifact.Kind())
+	}
+	return envs[0], nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92
 	github.com/carabiner-dev/predicates v0.5.0
 	github.com/carabiner-dev/sbomfs v0.1.0
-	github.com/carabiner-dev/signer v0.4.5
+	github.com/carabiner-dev/signer v0.4.6-0.20260428182929-2749e66cbe88
 	github.com/carabiner-dev/vcslocator v0.4.3
 	github.com/github/smimesign v0.2.0
 	github.com/go-git/go-billy/v5 v5.8.1-0.20260407233109-416e0a5b21a8
@@ -48,6 +48,7 @@ require (
 	github.com/avast/retry-go/v4 v4.7.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/carabiner-dev/command v0.3.1 // indirect
 	github.com/carabiner-dev/policy v0.5.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -134,6 +135,7 @@ require (
 	github.com/spdx/tools-golang v0.5.7 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/sudo-bmitch/oci-digest v0.1.2 // indirect
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
 	github.com/theupdateframework/go-tuf/v2 v2.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oM
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/carabiner-dev/attestation v0.2.1 h1:VhjV5YlO9TsW50Sr/Zd54bdbZhhDAqgxC3kB9z1I+3Q=
 github.com/carabiner-dev/attestation v0.2.1/go.mod h1:O84vF84RZG3pJO/6BYrPs718bZviHF5DKajP1HsrDpw=
+github.com/carabiner-dev/command v0.3.1 h1:iBkh+AjwziFZmyihv/izypCV74nkmaslZxb5AgP7GP4=
+github.com/carabiner-dev/command v0.3.1/go.mod h1:0mWfS5BU/krtaI1hgD5wjmLpjWVlf38KY8usA8zfF5c=
 github.com/carabiner-dev/ghrfs v0.3.4 h1:XJoDXkuw+8KQPTC4oI0da8vLpnx7cfQBGgyjzo+Eqrc=
 github.com/carabiner-dev/ghrfs v0.3.4/go.mod h1:u9We7molIUX6sCe4ox70juKOnbNAUpDv+B5Cerbqhio=
 github.com/carabiner-dev/github v0.2.3 h1:sky7HXTrgbk9G9gEWBmIeCExprHdnZvKOsFW1bUZXqc=
@@ -110,6 +112,8 @@ github.com/carabiner-dev/sbomfs v0.1.0 h1:gEsmn85hod7JTLs2dDr5C1x4Af7FUEhI0lbTur
 github.com/carabiner-dev/sbomfs v0.1.0/go.mod h1:UyPyTSNx9JOLZVgTmM9WXdmgVqDWXCYwr1LK1Ts+7H0=
 github.com/carabiner-dev/signer v0.4.5 h1:H3XHHqorZw7wvLysbGCc+FM90nSdzFlODj+mIGMsYJc=
 github.com/carabiner-dev/signer v0.4.5/go.mod h1:B/53ToJAIgwM+KuDwj52+HwnlA5p8Rmz2OXQdy9x+xs=
+github.com/carabiner-dev/signer v0.4.6-0.20260428182929-2749e66cbe88 h1:9Iij1K4kXYuKKk+2ZkrNR5pJjt/j1q6Yf7gGt7XPQlY=
+github.com/carabiner-dev/signer v0.4.6-0.20260428182929-2749e66cbe88/go.mod h1:lQXabEgyFNLm49T3K3PKmU//H1+hEIOsF+13ZKgXhCs=
 github.com/carabiner-dev/vcslocator v0.4.3 h1:rXKwVT8N4hS85GEJQGd0ZgOjTcALuCslsqZyg4g6qxA=
 github.com/carabiner-dev/vcslocator v0.4.3/go.mod h1:o0v3BV06HMg20GaJctA8feu0W/aan+XhHq0i+wr6Jq0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -444,6 +448,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
+github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
This pull request introduces a new helper function for handling signed artifacts and updates dependencies to support this functionality. The most important changes are summarized below.

### New functionality for signed artifacts

* Added a new function `FromSignedArtifact` in `envelope/envelope.go` that takes a `signer.SignedArtifact`, serializes it to canonical JSON, and parses it into an `attestation.Envelope` using the appropriate parser based on the artifact kind. This streamlines the process of converting signed artifacts into envelopes for further processing.
* Imported the `github.com/carabiner-dev/signer` package in `envelope/envelope.go` to enable the new functionality for handling signed artifacts.

### Dependency updates

* Upgraded `github.com/carabiner-dev/signer` to a newer pre-release version (`v0.4.6-0.20260428182929-2749e66cbe88`) in `go.mod` to support the new API used in `FromSignedArtifact`.
* Added `github.com/carabiner-dev/command` as an indirect dependency in `go.mod`.
* Added `github.com/spiffe/go-spiffe/v2` as an indirect dependency in `go.mod`.