### PR TITLE
Implement Storer interface in OCI collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following table lists all repository drivers currently implemented in the pr
 | Driver | Type Moniker | Description | Example Initialization String | Fetch | Store |
 | --- | --- | --- | --- | --- | --- |
 | **COCI** | `coci` | Reads Sigstore bundle attestations from container image registries using the `cosign` method. | `coci:docker.io/library/alpine:latest` | ✓ | ✗ |
-| **OCI** | `oci` | Reads Sigstore bundle attestations attached as OCI referrers (cosign v3). | `oci:ghcr.io/foo/bar:v1` | ✓ | ✗ |
+| **OCI** | `oci` | Reads and writes Sigstore bundle attestations attached as OCI referrers (cosign v3). | `oci:ghcr.io/foo/bar:v1` | ✓ | ✓ |
 | **Filesystem** | `fs` | Reads attestation files from a filesystem directory | `fs:/path/to/attestations` | ✓ | ✗ |
 | **GitHub** | `github` | Reads and writes attestations using the GitHub Attestations API | `github:owner/repo` | ✓ | ✓ |
 | **HTTP/HTTPS** | `http`, `https` | Fetches attestations from HTTP(S) endpoints serving JSONL or bundle formats | `https://example.com/attestations.jsonl` | ✓ | ✗ |

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -72,10 +72,10 @@ and synthesizes Sigstore bundles from the layer data and annotations
 
 ## oci (OCI Referrers)
 
-Fetches Sigstore bundle attestations attached as OCI referrers. Cosign v3
-attaches signatures and attestations as OCI artifacts that reference the
-subject image via the OCI Referrers API, rather than using the `.att`/`.sig`
-tag convention used by the **coci** collector.
+Reads and writes Sigstore bundle attestations attached as OCI referrers.
+Cosign v3 attaches signatures and attestations as OCI artifacts that
+reference the subject image via the OCI Referrers API, rather than using
+the `.att`/`.sig` tag convention used by the **coci** collector.
 
 The collector queries the Referrers API for artifacts with artifact type
 `application/vnd.dev.sigstore.bundle.v0.3+json`, pulls their blob layers,
@@ -85,9 +85,31 @@ Init string format: `oci:<image-ref>` (e.g. `oci:ghcr.io/foo/bar:v1` or
 `oci:ghcr.io/foo/bar@sha256:abc...`). Tag references are automatically
 resolved to digests before querying referrers.
 
-Authentication uses the Docker credential chain (`~/.docker/config.json`
-and configured credential helpers) and Docker CA certificates
-(`/etc/docker/certs.d`).
+Authentication uses the Docker credential chain (`~/.docker/config.json`,
+`$DOCKER_CONFIG`, `$DOCKER_AUTH_CONFIG`, and configured credential helpers)
+and Docker CA certificates (`/etc/docker/certs.d`). Callers can override
+this with `WithRegClientOpts` to inject custom registry hosts or transport
+options.
+
+When `Store` is called, each envelope is JSON-marshaled (the envelope is
+expected to be a Sigstore bundle, e.g. `*bundle.Envelope`) and uploaded as
+a new referrer pointing at the subject image:
+
+1. The subject reference is resolved via `ManifestHead` to capture its
+   digest, size, and media type.
+2. The bundle bytes are pushed as a blob with media type
+   `application/vnd.dev.sigstore.bundle.v0.3+json`.
+3. An empty `{}` config blob with media type
+   `application/vnd.oci.empty.v1+json` is pushed.
+4. An OCI image manifest is built with `artifactType` set to the Sigstore
+   bundle media type, the bundle blob as its single layer, and `subject`
+   pointing at the resolved image digest. The manifest is pushed at its
+   own content-addressable digest so the registry exposes it through the
+   Referrers API.
+
+The implementation is built directly on
+[`regclient`](https://github.com/regclient/regclient); it does not depend
+on `cosign`.
 
 ## release
 

--- a/repository/oci/collector.go
+++ b/repository/oci/collector.go
@@ -4,11 +4,15 @@
 package oci
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
 	"github.com/carabiner-dev/attestation"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/manifest"
@@ -31,7 +35,10 @@ var Build = func(istr string) (attestation.Repository, error) {
 	return New(WithReference(istr))
 }
 
-var _ attestation.Fetcher = (*Collector)(nil)
+var (
+	_ attestation.Fetcher = (*Collector)(nil)
+	_ attestation.Storer  = (*Collector)(nil)
+)
 
 // Collector fetches sigstore bundle attestations attached as OCI referrers.
 type Collector struct {
@@ -64,11 +71,7 @@ func (c *Collector) Fetch(ctx context.Context, opts attestation.FetchOptions) ([
 		return nil, fmt.Errorf("parsing reference: %w", err)
 	}
 
-	rcOpts := c.Options.regOpts
-	if len(rcOpts) == 0 {
-		rcOpts = []regclient.Opt{regclient.WithDockerCreds(), regclient.WithDockerCerts()}
-	}
-	rc := regclient.New(rcOpts...)
+	rc := c.newRegClient()
 
 	// Resolve tag to digest so we can query referrers.
 	if r.Digest == "" {
@@ -104,6 +107,118 @@ func (c *Collector) Fetch(ctx context.Context, opts attestation.FetchOptions) ([
 	}
 
 	return atts, nil
+}
+
+// newRegClient builds a regclient using the configured overrides or sensible
+// defaults that read credentials from the Docker config.
+func (c *Collector) newRegClient() *regclient.RegClient {
+	rcOpts := c.Options.regOpts
+	if len(rcOpts) == 0 {
+		rcOpts = []regclient.Opt{regclient.WithDockerCreds(), regclient.WithDockerCerts()}
+	}
+	return regclient.New(rcOpts...)
+}
+
+// Store implements the attestation.Storer interface. Each envelope is uploaded
+// as a sigstore bundle artifact attached to the configured image via the OCI
+// referrers API. Envelopes are expected to marshal as sigstore bundles (e.g.
+// *bundle.Envelope); other envelope types will be uploaded as-is and may not
+// be retrievable by sigstore-aware verifiers.
+func (c *Collector) Store(ctx context.Context, _ attestation.StoreOptions, envelopes []attestation.Envelope) error {
+	if len(envelopes) == 0 {
+		return nil
+	}
+
+	r, err := ref.New(c.Options.Reference)
+	if err != nil {
+		return fmt.Errorf("parsing reference: %w", err)
+	}
+
+	rc := c.newRegClient()
+
+	// Resolve the subject manifest so we can build a referrer pointing at it.
+	subjMan, err := rc.ManifestHead(ctx, r)
+	if err != nil {
+		return fmt.Errorf("resolving subject manifest: %w", err)
+	}
+	subjDesc := subjMan.GetDescriptor()
+	subjRef := r.SetDigest(subjDesc.Digest.String())
+
+	for i, env := range envelopes {
+		if err := c.storeEnvelope(ctx, rc, &subjRef, &subjDesc, env); err != nil {
+			return fmt.Errorf("storing envelope %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// storeEnvelope pushes a single envelope as a sigstore bundle referrer
+// attached to subjRef.
+func (c *Collector) storeEnvelope(
+	ctx context.Context,
+	rc *regclient.RegClient,
+	subjRef *ref.Ref,
+	subjDesc *descriptor.Descriptor,
+	env attestation.Envelope,
+) error {
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshaling envelope: %w", err)
+	}
+
+	bundleDesc := descriptor.Descriptor{
+		MediaType: sigstoreBundleArtifactType,
+		Digest:    digest.FromBytes(data),
+		Size:      int64(len(data)),
+	}
+	if _, err := rc.BlobPut(ctx, *subjRef, bundleDesc, bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("pushing bundle blob: %w", err)
+	}
+
+	emptyData := []byte("{}")
+	emptyDesc := descriptor.Descriptor{
+		MediaType: ocispec.MediaTypeEmptyJSON,
+		Digest:    digest.FromBytes(emptyData),
+		Size:      int64(len(emptyData)),
+	}
+	if _, err := rc.BlobPut(ctx, *subjRef, emptyDesc, bytes.NewReader(emptyData)); err != nil {
+		return fmt.Errorf("pushing empty config blob: %w", err)
+	}
+
+	m := &ocispec.Manifest{
+		MediaType:    ocispec.MediaTypeImageManifest,
+		ArtifactType: sigstoreBundleArtifactType,
+		Config: ocispec.Descriptor{
+			MediaType: emptyDesc.MediaType,
+			Digest:    emptyDesc.Digest,
+			Size:      emptyDesc.Size,
+		},
+		Layers: []ocispec.Descriptor{{
+			MediaType: bundleDesc.MediaType,
+			Digest:    bundleDesc.Digest,
+			Size:      bundleDesc.Size,
+		}},
+		Subject: &ocispec.Descriptor{
+			MediaType: subjDesc.MediaType,
+			Digest:    subjDesc.Digest,
+			Size:      subjDesc.Size,
+		},
+	}
+	m.SchemaVersion = 2
+
+	manData, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshaling referrer manifest: %w", err)
+	}
+	rcMan, err := manifest.New(manifest.WithRaw(manData))
+	if err != nil {
+		return fmt.Errorf("building referrer manifest: %w", err)
+	}
+	manRef := subjRef.SetDigest(digest.FromBytes(manData).String())
+	if err := rc.ManifestPut(ctx, manRef, rcMan); err != nil {
+		return fmt.Errorf("pushing referrer manifest: %w", err)
+	}
+	return nil
 }
 
 // fetchReferrer pulls the manifest for a single referrer descriptor and parses

--- a/repository/oci/collector_test.go
+++ b/repository/oci/collector_test.go
@@ -24,6 +24,8 @@ import (
 	rcmanifest "github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/stretchr/testify/require"
+
+	"github.com/carabiner-dev/collector/envelope/bundle"
 )
 
 // startRegistry starts an in-memory OCI registry backed by olareg and returns
@@ -313,6 +315,55 @@ func TestFetchWithLimit(t *testing.T) {
 	atts, err := c.Fetch(ctx, attestation.FetchOptions{Limit: 1})
 	require.NoError(t, err)
 	require.Len(t, atts, 1)
+}
+
+func TestStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+	host, hostOpt := startRegistry(t)
+
+	ctx := t.Context()
+	rc := regclient.New(hostOpt)
+
+	repo := host + "/test/store"
+	r, err := ref.New(repo + ":v1")
+	require.NoError(t, err)
+
+	pushSubjectImage(t, ctx, rc, &r)
+
+	bundleData, err := os.ReadFile("testdata/bundle-provenance.json")
+	require.NoError(t, err)
+
+	env := &bundle.Envelope{}
+	require.NoError(t, env.UnmarshalJSON(bundleData))
+
+	c, err := New(WithReference(repo+":v1"), WithRegClientOpts(hostOpt))
+	require.NoError(t, err)
+
+	require.NoError(t, c.Store(ctx, attestation.StoreOptions{}, []attestation.Envelope{env}))
+
+	atts, err := c.Fetch(ctx, attestation.FetchOptions{})
+	require.NoError(t, err)
+	require.Len(t, atts, 1)
+	require.NotNil(t, atts[0].GetStatement())
+	require.NotNil(t, atts[0].GetPredicate())
+}
+
+func TestStoreUnresolvableSubject(t *testing.T) {
+	t.Parallel()
+	host, hostOpt := startRegistry(t)
+
+	repo := host + "/test/missing"
+
+	c, err := New(WithReference(repo+":v1"), WithRegClientOpts(hostOpt))
+	require.NoError(t, err)
+
+	bundleData, err := os.ReadFile("testdata/bundle-provenance.json")
+	require.NoError(t, err)
+	env := &bundle.Envelope{}
+	require.NoError(t, env.UnmarshalJSON(bundleData))
+
+	err = c.Store(t.Context(), attestation.StoreOptions{}, []attestation.Envelope{env})
+	require.Error(t, err)
 }
 
 func TestFetchSkipsUnparseableLayers(t *testing.T) {


### PR DESCRIPTION
This pull request adds support for storing (writing) Sigstore bundle attestations as OCI referrers in the `oci` repository driver, in addition to the existing fetch (read) functionality. The documentation is updated to reflect these changes, and new tests are added to ensure correct store and fetch behavior. The implementation uses the `regclient` library directly for registry interactions.

**OCI repository driver enhancements:**

* Added support for storing (writing) Sigstore bundle attestations as OCI referrers via the `Store` method in the `Collector` class, making the `oci` driver both a fetcher and a storer. The implementation marshals each envelope as JSON and uploads it as a new referrer artifact pointing at the subject image, using the `regclient` library for registry operations. [[1]](diffhunk://#diff-e908c54de56ad7e23a243622c4e735b1f5735be61159b7e4f5188ee2d6254a1bL34-R41) [[2]](diffhunk://#diff-e908c54de56ad7e23a243622c4e735b1f5735be61159b7e4f5188ee2d6254a1bR112-R223)
* Refactored registry client creation into a `newRegClient` helper to allow for credential and transport overrides, improving configurability and code clarity.

**Documentation updates:**

* Updated the `README.md` and `docs/collectors.md` to indicate that the `oci` driver now supports both fetching and storing attestations, and added detailed documentation describing the store process, authentication, and implementation notes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R42) [[2]](diffhunk://#diff-ea32c75f2c786166afc00f6358debff799a68010a5ac6f495e011e7d9a55da4cL75-R78) [[3]](diffhunk://#diff-ea32c75f2c786166afc00f6358debff799a68010a5ac6f495e011e7d9a55da4cL88-R112)

**Testing improvements:**

* Added tests for round-trip storing and fetching of bundles, as well as error handling when attempting to store with an unresolvable subject image, increasing test coverage for the new store functionality.
* Added import for the `bundle` envelope type to support test cases involving Sigstore bundles.