### PR TITLE
Coci store

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following table lists all repository drivers currently implemented in the pr
 
 | Driver | Type Moniker | Description | Example Initialization String | Fetch | Store |
 | --- | --- | --- | --- | --- | --- |
-| **COCI** | `coci` | Reads Sigstore bundle attestations from container image registries using the `cosign` method. | `coci:docker.io/library/alpine:latest` | ✓ | ✗ |
+| **COCI** | `coci` | Reads and writes Sigstore bundle attestations on container image registries using the `cosign` method (`sha256-<digest>.att` tag). | `coci:docker.io/library/alpine:latest` | ✓ | ✓ |
 | **OCI** | `oci` | Reads and writes Sigstore bundle attestations attached as OCI referrers (cosign v3). | `oci:ghcr.io/foo/bar:v1` | ✓ | ✓ |
 | **Filesystem** | `fs` | Reads attestation files from a filesystem directory | `fs:/path/to/attestations` | ✓ | ✗ |
 | **GitHub** | `github` | Reads and writes attestations using the GitHub Attestations API | `github:owner/repo` | ✓ | ✓ |

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -65,10 +65,36 @@ lacks a SHA-1 or `gitCommit` subject, an error is returned.
 
 ## coci (Container OCI)
 
-Fetches attestations attached to OCI container images. Reads the `.att`
-tag manifest for a given image digest, iterates the DSSE envelope layers,
-and synthesizes Sigstore bundles from the layer data and annotations
-(certificates, transparency log entries, RFC 3161 timestamps).
+Reads and writes attestations attached to OCI container images using the
+legacy cosign tag convention (`<repo>:sha256-<digest>.att`). On read, the
+`.att` manifest is fetched, each DSSE envelope layer is pulled, and a
+Sigstore bundle is synthesized from the layer body plus its cosign
+annotations (certificates, transparency log entries, RFC 3161 timestamps).
+
+When `Store` is called the inverse path runs:
+
+1. The reference is resolved to its image digest so the `.att` tag can be
+   computed.
+2. The existing `.att` manifest (if any) is pulled so its layers are
+   preserved; new attestations are appended (cosign-style append-on-write).
+   A missing tag is treated as "no attestations yet" and a fresh empty
+   image is used as the base.
+3. Each envelope is converted to a DSSE layer with media type
+   `application/vnd.dsse.envelope.v1+json`. `*bundle.Envelope` inputs are
+   unwrapped: the DSSE payload becomes the layer body and any sigstore
+   verification material is hoisted back into cosign layer annotations
+   (`dev.sigstore.cosign/certificate`, `dev.sigstore.cosign/bundle`,
+   `dev.sigstore.cosign/rfc3161timestamp`) so the result round-trips with
+   both this collector's `Fetch` and with cosign itself.
+4. The resulting OCI image manifest is pushed at the `.att` tag.
+
+Authentication uses the standard Docker keychain
+(`~/.docker/config.json`, `$DOCKER_CONFIG`, configured credential helpers).
+Tests and other callers can override registry options via `WithCraneOpts`
+(e.g. `crane.Insecure` for an HTTP test registry). The implementation is
+built directly on
+[`go-containerregistry`](https://github.com/google/go-containerregistry);
+it does not depend on `cosign`.
 
 ## oci (OCI Referrers)
 

--- a/repository/coci/collector.go
+++ b/repository/coci/collector.go
@@ -48,7 +48,7 @@ type ImageInfo struct {
 	IsDigest    bool
 }
 
-func parseImageReference(ctx context.Context, ref string) (*ImageInfo, error) {
+func parseImageReference(ctx context.Context, ref string, opts ...crane.Option) (*ImageInfo, error) {
 	parsedRef, err := name.ParseReference(ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image reference: %w", err)
@@ -67,7 +67,8 @@ func parseImageReference(ctx context.Context, ref string) (*ImageInfo, error) {
 		info.Tag = v.TagStr()
 		info.IsDigest = false
 
-		digest, err := crane.Digest(ref, crane.WithContext(ctx))
+		digestOpts := append([]crane.Option{crane.WithContext(ctx)}, opts...)
+		digest, err := crane.Digest(ref, digestOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("getting reference digest: %w", err)
 		}
@@ -109,6 +110,7 @@ type (
 	optFn   = func(*Options) error
 	Options struct {
 		Reference string
+		craneOpts []crane.Option
 	}
 )
 
@@ -119,6 +121,16 @@ func WithReference(ref string) optFn {
 			return err
 		}
 		o.Reference = ref // perhaps parse?
+		return nil
+	}
+}
+
+// WithCraneOpts sets crane options that are applied to all registry calls
+// made by the collector (e.g. crane.Insecure for an HTTP test registry, or
+// custom auth/transport).
+func WithCraneOpts(opts ...crane.Option) optFn {
+	return func(o *Options) error {
+		o.craneOpts = append(o.craneOpts, opts...)
 		return nil
 	}
 }
@@ -134,6 +146,18 @@ type Collector struct {
 	Keys    []key.PublicKeyProvider
 }
 
+// craneOpts returns the crane options configured on the collector. It exists
+// as a method (rather than direct field access) so Fetch / Store call sites
+// can always start from a fresh slice.
+func (c *Collector) craneOpts() []crane.Option {
+	if len(c.Options.craneOpts) == 0 {
+		return nil
+	}
+	out := make([]crane.Option, len(c.Options.craneOpts))
+	copy(out, c.Options.craneOpts)
+	return out
+}
+
 // SetKeys sets the verification keys used by the collector.
 func (c *Collector) SetKeys(keys []key.PublicKeyProvider) {
 	c.Keys = keys
@@ -141,7 +165,7 @@ func (c *Collector) SetKeys(keys []key.PublicKeyProvider) {
 
 // Fetch queries the repository and retrieves any attestations matching the query
 func (c *Collector) Fetch(ctx context.Context, opts attestation.FetchOptions) ([]attestation.Envelope, error) {
-	imageInfo, err := parseImageReference(ctx, c.Options.Reference)
+	imageInfo, err := parseImageReference(ctx, c.Options.Reference, c.craneOpts()...)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +211,7 @@ func (c *Collector) fetchAttestationLayers(ctx context.Context, opts attestation
 			imageInfo.Registry, imageInfo.Repository,
 			strings.Replace(imageInfo.Digest, "sha256:", "sha256-", 1),
 		),
-		crane.WithContext(ctx),
+		append([]crane.Option{crane.WithContext(ctx)}, c.craneOpts()...)...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("fetching attestations manifest: %w", err)
@@ -226,7 +250,7 @@ func (c *Collector) fetchAttestationLayers(ctx context.Context, opts attestation
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			envelope, err := getAttestationEnvelope(ctx, &opts, imageInfo, dl.layer)
+			envelope, err := getAttestationEnvelope(ctx, &opts, imageInfo, dl.layer, c.craneOpts()...)
 			results[j] = layerResult{envelope, err, dl.index}
 		}(j, dl)
 	}
@@ -252,10 +276,10 @@ func (c *Collector) fetchAttestationLayers(ctx context.Context, opts attestation
 }
 
 // dsseEnvelopeFromOCILayer this reads the DSSE envelope containing the attestation
-func dsseEnvelopeFromOCILayer(ctx context.Context, opts *attestation.FetchOptions, imageInfo *ImageInfo, l *ggcr.Descriptor) (*protobundle.Bundle_DsseEnvelope, error) {
+func dsseEnvelopeFromOCILayer(ctx context.Context, opts *attestation.FetchOptions, imageInfo *ImageInfo, l *ggcr.Descriptor, craneOpts ...crane.Option) (*protobundle.Bundle_DsseEnvelope, error) {
 	// Build the attestation blob reference
 	attRef := imageInfo.Registry + "/" + imageInfo.Repository + "@" + l.Digest.String()
-	layer, err := crane.PullLayer(attRef, crane.WithContext(ctx))
+	layer, err := crane.PullLayer(attRef, append([]crane.Option{crane.WithContext(ctx)}, craneOpts...)...)
 	if err != nil {
 		return nil, fmt.Errorf("pulling layer data: %w", err)
 	}
@@ -359,8 +383,8 @@ func getVerificationMaterialTimestampEntries(manifestLayer *ggcr.Descriptor) (*p
 // (certificate, tlog entries, etc.) a full sigstore bundle is returned.
 // Otherwise the payload is returned as a plain DSSE envelope that can be
 // verified with a public key.
-func getAttestationEnvelope(ctx context.Context, opts *attestation.FetchOptions, imageInfo *ImageInfo, layer *ggcr.Descriptor) (attestation.Envelope, error) {
-	dsseEnv, err := dsseEnvelopeFromOCILayer(ctx, opts, imageInfo, layer)
+func getAttestationEnvelope(ctx context.Context, opts *attestation.FetchOptions, imageInfo *ImageInfo, layer *ggcr.Descriptor, craneOpts ...crane.Option) (attestation.Envelope, error) {
+	dsseEnv, err := dsseEnvelopeFromOCILayer(ctx, opts, imageInfo, layer, craneOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting dsse envelope from layer: %w", err)
 	}

--- a/repository/coci/signature.go
+++ b/repository/coci/signature.go
@@ -48,7 +48,7 @@ func (c *Collector) fetchSignatures(ctx context.Context, opts attestation.FetchO
 		strings.Replace(imageInfo.Digest, "sha256:", "sha256-", 1),
 	)
 
-	manifestData, err := crane.Manifest(sigRef, crane.WithContext(ctx))
+	manifestData, err := crane.Manifest(sigRef, append([]crane.Option{crane.WithContext(ctx)}, c.craneOpts()...)...)
 	if err != nil {
 		return nil, fmt.Errorf("fetching .sig manifest: %w", err)
 	}
@@ -113,7 +113,7 @@ func (c *Collector) fetchSignatures(ctx context.Context, opts attestation.FetchO
 func (c *Collector) getSignatureEnvelope(ctx context.Context, opts *attestation.FetchOptions, imageInfo *ImageInfo, layer *ggcr.Descriptor) (attestation.Envelope, error) {
 	// Pull the layer blob (simple signing payload)
 	layerRef := imageInfo.Registry + "/" + imageInfo.Repository + "@" + layer.Digest.String()
-	pulled, err := crane.PullLayer(layerRef, crane.WithContext(ctx))
+	pulled, err := crane.PullLayer(layerRef, append([]crane.Option{crane.WithContext(ctx)}, c.craneOpts()...)...)
 	if err != nil {
 		return nil, fmt.Errorf("pulling signature layer: %w", err)
 	}

--- a/repository/coci/storer.go
+++ b/repository/coci/storer.go
@@ -17,12 +17,12 @@ import (
 
 	"github.com/carabiner-dev/attestation"
 	"github.com/google/go-containerregistry/pkg/crane"
+	ggcr "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	ggcr "github.com/google/go-containerregistry/pkg/v1"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
@@ -148,7 +148,7 @@ func isNotFound(err error) bool {
 func dsseLayerForEnvelope(env attestation.Envelope) ([]byte, *protobundle.VerificationMaterial, error) {
 	switch e := env.(type) {
 	case *bundle.Envelope:
-		de := e.Bundle.GetDsseEnvelope()
+		de := e.GetDsseEnvelope()
 		if de == nil {
 			return nil, nil, fmt.Errorf("bundle envelope does not contain a DSSE envelope; only DSSE-wrapped attestations can be stored as cosign .att layers")
 		}
@@ -156,7 +156,7 @@ func dsseLayerForEnvelope(env attestation.Envelope) ([]byte, *protobundle.Verifi
 		if err != nil {
 			return nil, nil, fmt.Errorf("marshaling DSSE envelope: %w", err)
 		}
-		return data, e.Bundle.GetVerificationMaterial(), nil
+		return data, e.GetVerificationMaterial(), nil
 	case *dsse.Envelope:
 		if e.Envelope == nil {
 			return nil, nil, fmt.Errorf("dsse envelope is empty")

--- a/repository/coci/storer.go
+++ b/repository/coci/storer.go
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package coci
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/carabiner-dev/attestation"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	ggcr "github.com/google/go-containerregistry/pkg/v1"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/carabiner-dev/collector/envelope/bundle"
+	"github.com/carabiner-dev/collector/envelope/dsse"
+)
+
+// dsseEnvelopeMediaType is the layer media type cosign uses for DSSE-wrapped
+// attestation payloads in the legacy `.att` tag layout.
+const dsseEnvelopeMediaType = "application/vnd.dsse.envelope.v1+json"
+
+var _ attestation.Storer = (*Collector)(nil)
+
+// Store implements the attestation.Storer interface. Each envelope is appended
+// as a DSSE layer to the cosign-style attestation image at
+// `<repo>:sha256-<digest>.att`. If an attestation image already exists at that
+// tag, its existing layers are preserved (append-on-write, mirroring cosign).
+//
+// Bundle envelopes (`*bundle.Envelope`) are unwrapped: the DSSE payload is
+// pushed as the layer body, and any sigstore verification material is hoisted
+// into the cosign layer annotations (`dev.sigstore.cosign/certificate`,
+// `dev.sigstore.cosign/bundle`, `dev.sigstore.cosign/rfc3161timestamp`) so the
+// resulting image is fully round-trippable with cosign and with this
+// collector's own `Fetch`.
+func (c *Collector) Store(ctx context.Context, _ attestation.StoreOptions, envelopes []attestation.Envelope) error {
+	if len(envelopes) == 0 {
+		return nil
+	}
+
+	imageInfo, err := parseImageReference(ctx, c.Options.Reference, c.craneOpts()...)
+	if err != nil {
+		return fmt.Errorf("parsing reference: %w", err)
+	}
+
+	attTag := fmt.Sprintf(
+		"%s/%s:%s.att",
+		imageInfo.Registry, imageInfo.Repository,
+		strings.Replace(imageInfo.Digest, "sha256:", "sha256-", 1),
+	)
+
+	base, err := pullExistingOrEmpty(ctx, attTag, c.craneOpts()...)
+	if err != nil {
+		return fmt.Errorf("preparing base attestation image: %w", err)
+	}
+
+	addendums := make([]mutate.Addendum, 0, len(envelopes))
+	for i, env := range envelopes {
+		layerBytes, material, err := dsseLayerForEnvelope(env)
+		if err != nil {
+			return fmt.Errorf("preparing layer for envelope %d: %w", i, err)
+		}
+		annotations, err := cosignAnnotationsFromMaterial(material)
+		if err != nil {
+			return fmt.Errorf("building cosign annotations for envelope %d: %w", i, err)
+		}
+		addendums = append(addendums, mutate.Addendum{
+			Layer:       static.NewLayer(layerBytes, dsseEnvelopeMediaType),
+			Annotations: annotations,
+		})
+	}
+
+	img, err := mutate.Append(base, addendums...)
+	if err != nil {
+		return fmt.Errorf("appending attestation layers: %w", err)
+	}
+	img = mutate.MediaType(img, types.OCIManifestSchema1)
+	img = mutate.ConfigMediaType(img, types.OCIConfigJSON)
+
+	opts := append([]crane.Option{crane.WithContext(ctx)}, c.craneOpts()...)
+	if err := crane.Push(img, attTag, opts...); err != nil {
+		return fmt.Errorf("pushing attestation image to %s: %w", attTag, err)
+	}
+	return nil
+}
+
+// pullExistingOrEmpty fetches the current attestation image at attTag so its
+// layers can be preserved when new attestations are appended. A
+// MANIFEST_UNKNOWN / 404 response is treated as "no attestations yet" and an
+// empty image is returned instead.
+func pullExistingOrEmpty(ctx context.Context, attTag string, opts ...crane.Option) (ggcr.Image, error) {
+	pullOpts := append([]crane.Option{crane.WithContext(ctx)}, opts...)
+	img, err := crane.Pull(attTag, pullOpts...)
+	if err == nil {
+		return img, nil
+	}
+	if isNotFound(err) {
+		return empty.Image, nil
+	}
+	return nil, err
+}
+
+// isNotFound returns true when err signals that a registry manifest does not
+// exist yet (404 / MANIFEST_UNKNOWN). Anything else is treated as a real
+// failure so we don't silently drop existing attestations.
+func isNotFound(err error) bool {
+	var tErr *transport.Error
+	if !errors.As(err, &tErr) {
+		return false
+	}
+	if tErr.StatusCode == http.StatusNotFound {
+		return true
+	}
+	for _, d := range tErr.Errors {
+		if d.Code == transport.ManifestUnknownErrorCode || d.Code == transport.NameUnknownErrorCode {
+			return true
+		}
+	}
+	return false
+}
+
+// dsseLayerForEnvelope returns the DSSE JSON bytes that should be used as the
+// `.att` layer body for env, along with any sigstore verification material
+// that should be hoisted into cosign layer annotations.
+//
+// For `*bundle.Envelope` the embedded DSSE envelope and verification material
+// are extracted directly. For `*dsse.Envelope` the wrapped protobuf DSSE is
+// marshaled and no material is returned. Anything else is JSON-marshaled
+// best-effort and the caller's verifier is responsible for making sense of
+// the resulting layer.
+func dsseLayerForEnvelope(env attestation.Envelope) ([]byte, *protobundle.VerificationMaterial, error) {
+	switch e := env.(type) {
+	case *bundle.Envelope:
+		de := e.Bundle.GetDsseEnvelope()
+		if de == nil {
+			return nil, nil, fmt.Errorf("bundle envelope does not contain a DSSE envelope; only DSSE-wrapped attestations can be stored as cosign .att layers")
+		}
+		data, err := marshalProto(de)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshaling DSSE envelope: %w", err)
+		}
+		return data, e.Bundle.GetVerificationMaterial(), nil
+	case *dsse.Envelope:
+		if e.Envelope == nil {
+			return nil, nil, fmt.Errorf("dsse envelope is empty")
+		}
+		data, err := marshalProto(e.Envelope)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshaling DSSE envelope: %w", err)
+		}
+		return data, nil, nil
+	default:
+		data, err := json.Marshal(env)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshaling envelope: %w", err)
+		}
+		return data, nil, nil
+	}
+}
+
+// marshalProto serializes a google-protobuf message using protojson with the
+// defaults that match what cosign / sigstore consumers expect for DSSE layer
+// bodies.
+func marshalProto(m proto.Message) ([]byte, error) {
+	return (protojson.MarshalOptions{UseProtoNames: false, EmitUnpopulated: false}).Marshal(m)
+}
+
+// cosignAnnotationsFromMaterial converts sigstore verification material into
+// the cosign layer annotation set used by the legacy .att tag layout. Returns
+// nil when there's nothing to hoist (e.g. plain key-signed DSSE).
+func cosignAnnotationsFromMaterial(material *protobundle.VerificationMaterial) (map[string]string, error) {
+	if material == nil {
+		return nil, nil
+	}
+	annotations := map[string]string{}
+
+	if chain := material.GetX509CertificateChain(); chain != nil {
+		certs := chain.GetCertificates()
+		if len(certs) > 0 && len(certs[0].GetRawBytes()) > 0 {
+			pemBytes := pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: certs[0].GetRawBytes(),
+			})
+			if pemBytes == nil {
+				return nil, fmt.Errorf("encoding signing certificate to PEM")
+			}
+			annotations["dev.sigstore.cosign/certificate"] = string(pemBytes)
+		}
+	}
+
+	if entries := material.GetTlogEntries(); len(entries) > 0 {
+		ann, err := buildCosignBundleAnnotation(entries[0])
+		if err != nil {
+			return nil, fmt.Errorf("building bundle annotation: %w", err)
+		}
+		annotations["dev.sigstore.cosign/bundle"] = ann
+	}
+
+	if td := material.GetTimestampVerificationData(); td != nil {
+		if ts := td.GetRfc3161Timestamps(); len(ts) > 0 && len(ts[0].GetSignedTimestamp()) > 0 {
+			ann, err := buildCosignTimestampAnnotation(ts[0])
+			if err != nil {
+				return nil, fmt.Errorf("building rfc3161 timestamp annotation: %w", err)
+			}
+			annotations["dev.sigstore.cosign/rfc3161timestamp"] = ann
+		}
+	}
+
+	if len(annotations) == 0 {
+		return nil, nil
+	}
+	return annotations, nil
+}
+
+// buildCosignBundleAnnotation re-serializes a rekor transparency log entry
+// into the JSON shape that cosign embeds in the
+// `dev.sigstore.cosign/bundle` layer annotation. It is the inverse of
+// getVerificationMaterialTlogEntries in collector.go.
+func buildCosignBundleAnnotation(entry *protorekor.TransparencyLogEntry) (string, error) {
+	payload := map[string]any{
+		"body":           base64.StdEncoding.EncodeToString(entry.GetCanonicalizedBody()),
+		"integratedTime": entry.GetIntegratedTime(),
+		"logIndex":       entry.GetLogIndex(),
+	}
+	if logID := entry.GetLogId(); logID != nil && len(logID.GetKeyId()) > 0 {
+		payload["logID"] = hex.EncodeToString(logID.GetKeyId())
+	}
+
+	wrapper := map[string]any{
+		"Payload": payload,
+	}
+	if ip := entry.GetInclusionPromise(); ip != nil && len(ip.GetSignedEntryTimestamp()) > 0 {
+		wrapper["SignedEntryTimestamp"] = base64.StdEncoding.EncodeToString(ip.GetSignedEntryTimestamp())
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(wrapper); err != nil {
+		return "", err
+	}
+	return strings.TrimRight(buf.String(), "\n"), nil
+}
+
+// buildCosignTimestampAnnotation produces the JSON body of the
+// `dev.sigstore.cosign/rfc3161timestamp` annotation from a SignedRFC3161
+// timestamp.
+func buildCosignTimestampAnnotation(ts *protocommon.RFC3161SignedTimestamp) (string, error) {
+	payload := map[string]string{
+		"SignedRFC3161Timestamp": base64.StdEncoding.EncodeToString(ts.GetSignedTimestamp()),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/repository/coci/storer_test.go
+++ b/repository/coci/storer_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/carabiner-dev/attestation"
@@ -309,7 +308,7 @@ func TestDSSELayerForEnvelopeBundle(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, material)
 	require.NotEmpty(t, data)
-	require.True(t, strings.Contains(string(data), `"payloadType"`))
+	require.Contains(t, string(data), `"payloadType"`)
 }
 
 func TestDSSELayerForEnvelopeBundleWithoutDSSE(t *testing.T) {
@@ -336,5 +335,5 @@ func TestDSSELayerForEnvelopePlainDSSE(t *testing.T) {
 	data, material, err := dsseLayerForEnvelope(env)
 	require.NoError(t, err)
 	require.Nil(t, material)
-	require.True(t, strings.Contains(string(data), `"payloadType"`))
+	require.Contains(t, string(data), `"payloadType"`)
 }

--- a/repository/coci/storer_test.go
+++ b/repository/coci/storer_test.go
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package coci
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/carabiner-dev/attestation"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/olareg/olareg"
+	olaregconfig "github.com/olareg/olareg/config"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	protodsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	sbundle "github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/stretchr/testify/require"
+
+	"github.com/carabiner-dev/collector/envelope/bundle"
+	"github.com/carabiner-dev/collector/envelope/dsse"
+)
+
+func startTestRegistry(t *testing.T) string {
+	t.Helper()
+	srv := olareg.New(olaregconfig.Config{
+		Storage: olaregconfig.ConfigStorage{
+			StoreType: olaregconfig.StoreMem,
+		},
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		ts.Close()
+		if err := srv.Close(); err != nil {
+			t.Logf("closing olareg: %v", err)
+		}
+	})
+	tsURL, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	return tsURL.Host
+}
+
+// pushEmptySubject pushes a minimal empty image to ref so the registry has a
+// subject for the .att tag to point at, and returns its digest in
+// `sha256:<hex>` form.
+func pushEmptySubject(t *testing.T, ctx context.Context, ref string) string {
+	t.Helper()
+	require.NoError(t, crane.Push(empty.Image, ref, crane.WithContext(ctx), crane.Insecure))
+	d, err := crane.Digest(ref, crane.WithContext(ctx), crane.Insecure)
+	require.NoError(t, err)
+	return d
+}
+
+// validIntotoPayload builds a tiny valid in-toto statement so the round-trip
+// fetch path can produce a non-nil Statement.
+func validIntotoPayload() []byte {
+	return []byte(`{"_type":"https://in-toto.io/Statement/v1","predicateType":"https://example.com/test/v1","subject":[{"name":"x","digest":{"sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}}],"predicate":{}}`)
+}
+
+func makeDSSEEnvelope() *dsse.Envelope {
+	return &dsse.Envelope{
+		Envelope: &protodsse.Envelope{
+			PayloadType: "application/vnd.in-toto+json",
+			Payload:     validIntotoPayload(),
+			Signatures: []*protodsse.Signature{
+				{Keyid: "k", Sig: []byte("sig")},
+			},
+		},
+	}
+}
+
+func TestStoreRoundTripPlainDSSE(t *testing.T) {
+	t.Parallel()
+	host := startTestRegistry(t)
+	ctx := t.Context()
+
+	repo := fmt.Sprintf("%s/test/coci/dsse:v1", host)
+	pushEmptySubject(t, ctx, repo)
+
+	c, err := New(WithReference(repo), WithCraneOpts(crane.Insecure))
+	require.NoError(t, err)
+
+	env := makeDSSEEnvelope()
+	require.NoError(t, c.Store(ctx, attestation.StoreOptions{}, []attestation.Envelope{env}))
+
+	atts, err := c.Fetch(ctx, attestation.FetchOptions{})
+	require.NoError(t, err)
+	require.Len(t, atts, 1)
+	require.NotNil(t, atts[0].GetStatement())
+}
+
+func TestStoreAppendsToExistingAttestationImage(t *testing.T) {
+	t.Parallel()
+	host := startTestRegistry(t)
+	ctx := t.Context()
+
+	repo := fmt.Sprintf("%s/test/coci/append:v1", host)
+	pushEmptySubject(t, ctx, repo)
+
+	c, err := New(WithReference(repo), WithCraneOpts(crane.Insecure))
+	require.NoError(t, err)
+
+	// First write.
+	require.NoError(t, c.Store(ctx, attestation.StoreOptions{}, []attestation.Envelope{makeDSSEEnvelope()}))
+	// Second write — must preserve the first and append the second.
+	require.NoError(t, c.Store(ctx, attestation.StoreOptions{}, []attestation.Envelope{makeDSSEEnvelope()}))
+
+	atts, err := c.Fetch(ctx, attestation.FetchOptions{})
+	require.NoError(t, err)
+	require.Len(t, atts, 2, "appending should preserve prior layers")
+}
+
+func TestStoreRoundTripBundleWithCosignAnnotations(t *testing.T) {
+	t.Parallel()
+	host := startTestRegistry(t)
+	ctx := t.Context()
+
+	repo := fmt.Sprintf("%s/test/coci/bundle:v1", host)
+	pushEmptySubject(t, ctx, repo)
+
+	c, err := New(WithReference(repo), WithCraneOpts(crane.Insecure))
+	require.NoError(t, err)
+
+	mt, err := sbundle.MediaTypeString("v0.3")
+	require.NoError(t, err)
+
+	// Build a bundle envelope with sigstore verification material so the
+	// storer must hoist it into cosign layer annotations and the fetcher must
+	// re-parse it back into a bundle on read.
+	fakeCert := []byte{0x30, 0x82, 0x01, 0x0a} // not a real cert; only used to round-trip RawBytes
+	logIDBytes := []byte{0xab, 0xcd, 0xef}
+	setBytes := []byte("signed-entry-timestamp")
+	canonicalBody := []byte(`{"kind":"hashedrekord","apiVersion":"0.0.1"}`)
+	tsDER := []byte("rfc3161-der-bytes")
+
+	bun := &bundle.Envelope{
+		Bundle: protobundle.Bundle{
+			MediaType: mt,
+			Content: &protobundle.Bundle_DsseEnvelope{
+				DsseEnvelope: &protodsse.Envelope{
+					PayloadType: "application/vnd.in-toto+json",
+					Payload:     validIntotoPayload(),
+					Signatures: []*protodsse.Signature{
+						{Keyid: "k", Sig: []byte("sig")},
+					},
+				},
+			},
+			VerificationMaterial: &protobundle.VerificationMaterial{
+				Content: &protobundle.VerificationMaterial_X509CertificateChain{
+					X509CertificateChain: &protocommon.X509CertificateChain{
+						Certificates: []*protocommon.X509Certificate{{RawBytes: fakeCert}},
+					},
+				},
+				TlogEntries: []*protorekor.TransparencyLogEntry{{
+					LogIndex:          42,
+					LogId:             &protocommon.LogId{KeyId: logIDBytes},
+					IntegratedTime:    1700000000,
+					InclusionPromise:  &protorekor.InclusionPromise{SignedEntryTimestamp: setBytes},
+					CanonicalizedBody: canonicalBody,
+				}},
+				TimestampVerificationData: &protobundle.TimestampVerificationData{
+					Rfc3161Timestamps: []*protocommon.RFC3161SignedTimestamp{
+						{SignedTimestamp: tsDER},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, c.Store(ctx, attestation.StoreOptions{}, []attestation.Envelope{bun}))
+
+	atts, err := c.Fetch(ctx, attestation.FetchOptions{})
+	require.NoError(t, err)
+	require.Len(t, atts, 1)
+
+	got, ok := atts[0].(*bundle.Envelope)
+	require.True(t, ok, "fetched envelope should be a bundle.Envelope since cosign annotations were preserved")
+
+	// Cert chain round-tripped.
+	chain := got.Bundle.GetVerificationMaterial().GetX509CertificateChain()
+	require.NotNil(t, chain)
+	require.Len(t, chain.GetCertificates(), 1)
+	require.Equal(t, fakeCert, chain.GetCertificates()[0].GetRawBytes())
+
+	// Tlog entry round-tripped — the fetch path repopulates LogIndex,
+	// IntegratedTime, LogId, SignedEntryTimestamp, and CanonicalizedBody.
+	tlogs := got.Bundle.GetVerificationMaterial().GetTlogEntries()
+	require.Len(t, tlogs, 1)
+	require.EqualValues(t, 42, tlogs[0].GetLogIndex())
+	require.EqualValues(t, 1700000000, tlogs[0].GetIntegratedTime())
+	require.Equal(t, logIDBytes, tlogs[0].GetLogId().GetKeyId())
+	require.Equal(t, setBytes, tlogs[0].GetInclusionPromise().GetSignedEntryTimestamp())
+	require.Equal(t, canonicalBody, tlogs[0].GetCanonicalizedBody())
+
+	// RFC3161 timestamp round-tripped.
+	ts := got.Bundle.GetVerificationMaterial().GetTimestampVerificationData().GetRfc3161Timestamps()
+	require.Len(t, ts, 1)
+	require.Equal(t, tsDER, ts[0].GetSignedTimestamp())
+}
+
+func TestStoreEmptyEnvelopesIsNoop(t *testing.T) {
+	t.Parallel()
+	host := startTestRegistry(t)
+	ctx := t.Context()
+
+	repo := fmt.Sprintf("%s/test/coci/empty:v1", host)
+	pushEmptySubject(t, ctx, repo)
+
+	c, err := New(WithReference(repo), WithCraneOpts(crane.Insecure))
+	require.NoError(t, err)
+
+	require.NoError(t, c.Store(ctx, attestation.StoreOptions{}, nil))
+}
+
+func TestCosignAnnotationsFromMaterialNil(t *testing.T) {
+	t.Parallel()
+	ann, err := cosignAnnotationsFromMaterial(nil)
+	require.NoError(t, err)
+	require.Nil(t, ann)
+}
+
+func TestCosignAnnotationsFromMaterialShapes(t *testing.T) {
+	t.Parallel()
+	logID := []byte{0x01, 0x02}
+	mat := &protobundle.VerificationMaterial{
+		Content: &protobundle.VerificationMaterial_X509CertificateChain{
+			X509CertificateChain: &protocommon.X509CertificateChain{
+				Certificates: []*protocommon.X509Certificate{{RawBytes: []byte("cert")}},
+			},
+		},
+		TlogEntries: []*protorekor.TransparencyLogEntry{{
+			LogIndex:          7,
+			LogId:             &protocommon.LogId{KeyId: logID},
+			IntegratedTime:    12345,
+			InclusionPromise:  &protorekor.InclusionPromise{SignedEntryTimestamp: []byte("set")},
+			CanonicalizedBody: []byte("body"),
+		}},
+		TimestampVerificationData: &protobundle.TimestampVerificationData{
+			Rfc3161Timestamps: []*protocommon.RFC3161SignedTimestamp{
+				{SignedTimestamp: []byte("ts")},
+			},
+		},
+	}
+
+	ann, err := cosignAnnotationsFromMaterial(mat)
+	require.NoError(t, err)
+
+	// Certificate is PEM-encoded.
+	certPEM := ann["dev.sigstore.cosign/certificate"]
+	require.NotEmpty(t, certPEM)
+	block, _ := pem.Decode([]byte(certPEM))
+	require.NotNil(t, block)
+	require.Equal(t, "CERTIFICATE", block.Type)
+	require.Equal(t, []byte("cert"), block.Bytes)
+
+	// Bundle annotation has the right shape.
+	bundleJSON := ann["dev.sigstore.cosign/bundle"]
+	require.NotEmpty(t, bundleJSON)
+	var b struct {
+		Payload struct {
+			Body           string `json:"body"`
+			IntegratedTime int64  `json:"integratedTime"`
+			LogIndex       int64  `json:"logIndex"`
+			LogID          string `json:"logID"`
+		} `json:"Payload"`
+		SignedEntryTimestamp string `json:"SignedEntryTimestamp"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(bundleJSON), &b))
+	require.EqualValues(t, 7, b.Payload.LogIndex)
+	require.EqualValues(t, 12345, b.Payload.IntegratedTime)
+	require.Equal(t, hex.EncodeToString(logID), b.Payload.LogID)
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("body")), b.Payload.Body)
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("set")), b.SignedEntryTimestamp)
+
+	// Timestamp annotation has the right shape.
+	tsJSON := ann["dev.sigstore.cosign/rfc3161timestamp"]
+	require.NotEmpty(t, tsJSON)
+	var ts struct {
+		SignedRFC3161Timestamp string `json:"SignedRFC3161Timestamp"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(tsJSON), &ts))
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("ts")), ts.SignedRFC3161Timestamp)
+}
+
+func TestDSSELayerForEnvelopeBundle(t *testing.T) {
+	t.Parallel()
+	bun := &bundle.Envelope{
+		Bundle: protobundle.Bundle{
+			Content: &protobundle.Bundle_DsseEnvelope{
+				DsseEnvelope: &protodsse.Envelope{
+					PayloadType: "x",
+					Payload:     []byte("p"),
+				},
+			},
+			VerificationMaterial: &protobundle.VerificationMaterial{},
+		},
+	}
+	data, material, err := dsseLayerForEnvelope(bun)
+	require.NoError(t, err)
+	require.NotNil(t, material)
+	require.NotEmpty(t, data)
+	require.True(t, strings.Contains(string(data), `"payloadType"`))
+}
+
+func TestDSSELayerForEnvelopeBundleWithoutDSSE(t *testing.T) {
+	t.Parallel()
+	bun := &bundle.Envelope{
+		Bundle: protobundle.Bundle{
+			Content: &protobundle.Bundle_MessageSignature{
+				MessageSignature: &protocommon.MessageSignature{},
+			},
+		},
+	}
+	_, _, err := dsseLayerForEnvelope(bun)
+	require.Error(t, err)
+}
+
+func TestDSSELayerForEnvelopePlainDSSE(t *testing.T) {
+	t.Parallel()
+	env := &dsse.Envelope{
+		Envelope: &protodsse.Envelope{
+			PayloadType: "x",
+			Payload:     []byte("p"),
+		},
+	}
+	data, material, err := dsseLayerForEnvelope(env)
+	require.NoError(t, err)
+	require.Nil(t, material)
+	require.True(t, strings.Contains(string(data), `"payloadType"`))
+}


### PR DESCRIPTION
This pull request adds support for writing (storing) Sigstore bundle attestations to container image registries using the legacy cosign `.att` tag format in the `coci` repository driver. It also introduces a new `Store` implementation for the `coci` collector, allows custom registry options (like insecure/test registries), and updates documentation to reflect these capabilities.

**Major new functionality:**

* Implemented the `Store` method for the `coci` collector in `repository/coci/storer.go`, enabling writing/appending attestations to container registries using the cosign `.att` tag convention. This includes full round-tripping of Sigstore bundle verification material via cosign-compatible layer annotations.

**Configuration and extensibility:**

* Added `WithCraneOpts` option and related plumbing to allow callers to specify custom `crane.Option` values (e.g., for authentication, insecure registries, or custom transports) for all registry operations in the `coci` collector. All relevant registry calls now accept and use these options. [[1]](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eR113) [[2]](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eR128-R137) [[3]](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eR149-R168) [[4]](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL70-R71) [[5]](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL190-R214) [[6]](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL229-R253) [[7]](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL255-R282) [[8]](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL362-R387) [[9]](diffhunk://#diff-7351867d9b504fa5a69fa02954d6ff66ee464bb771568594bb7f07b2f8a5f501L51-R51) [[10]](diffhunk://#diff-7351867d9b504fa5a69fa02954d6ff66ee464bb771568594bb7f07b2f8a5f501L116-R116) [[11]](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL51-R51)

**Documentation updates:**

* Updated the `README.md` and `docs/collectors.md` to clarify that the `coci` driver now supports both reading and writing attestations, and provided detailed documentation of the new write behavior and authentication options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R41) [[2]](diffhunk://#diff-ea32c75f2c786166afc00f6358debff799a68010a5ac6f495e011e7d9a55da4cL68-R97)

---

**References:**
- [repository/coci/storer.goR1-R274](diffhunk://#diff-fe41a7a7fcb58a6a729987bb05359bb4fd207de538b8e3c8df831e42f6eb11d3R1-R274)
- [repository/coci/collector.goR113](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eR113)
- [repository/coci/collector.goR128-R137](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eR128-R137)
- [repository/coci/collector.goR149-R168](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eR149-R168)
- [repository/coci/collector.goL70-R71](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL70-R71)
- [repository/coci/collector.goL190-R214](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL190-R214)
- [repository/coci/collector.goL229-R253](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL229-R253)
- [repository/coci/collector.goL255-R282](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL255-R282)
- [repository/coci/collector.goL362-R387](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL362-R387)
- [repository/coci/signature.goL51-R51](diffhunk://#diff-7351867d9b504fa5a69fa02954d6ff66ee464bb771568594bb7f07b2f8a5f501L51-R51)
- [repository/coci/signature.goL116-R116](diffhunk://#diff-7351867d9b504fa5a69fa02954d6ff66ee464bb771568594bb7f07b2f8a5f501L116-R116)
- [repository/coci/collector.goL51-R51](diffhunk://#diff-567dc89857d4ca4ece753a51554e633a35722dedb35235f528fad6510eb0621eL51-R51)
- [README.mdL41-R41](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R41)
- [docs/collectors.mdL68-R97](diffhunk://#diff-ea32c75f2c786166afc00f6358debff799a68010a5ac6f495e011e7d9a55da4cL68-R97)