### PR TITLE
fs: don't fail collection on unparseable files

### DIFF
--- a/repository/filesystem/collector.go
+++ b/repository/filesystem/collector.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/carabiner-dev/attestation"
 	"github.com/carabiner-dev/signer/key"
+	"github.com/sirupsen/logrus"
 
 	"github.com/carabiner-dev/collector/envelope"
 	"github.com/carabiner-dev/collector/filters"
@@ -172,7 +173,10 @@ func (c *Collector) Fetch(ctx context.Context, opts attestation.FetchOptions) ([
 			attestations, err = envelope.Parsers.Parse(bytes.NewReader(bs))
 		}
 		if err != nil {
-			return fmt.Errorf("parsing file %q: %w", path, err)
+			// An unparseable file shouldn't fail the whole collection —
+			// log and continue.
+			logrus.Debugf("skipping %s: parsing attestations: %v", path, err)
+			return nil
 		}
 
 		if opts.Query != nil {

--- a/repository/filesystem/collector_test.go
+++ b/repository/filesystem/collector_test.go
@@ -6,6 +6,7 @@ package filesystem
 import (
 	"os"
 	"testing"
+	"testing/fstest"
 
 	"github.com/carabiner-dev/attestation"
 	"github.com/stretchr/testify/require"
@@ -47,6 +48,33 @@ func TestFetch(t *testing.T) {
 			require.Len(t, atts, tc.expect)
 		})
 	}
+}
+
+func TestFetchSkipsUnparseableFiles(t *testing.T) {
+	t.Parallel()
+
+	good, err := os.ReadFile("testdata/results.intoto.json")
+	require.NoError(t, err)
+
+	fsys := fstest.MapFS{
+		"results.intoto.json": &fstest.MapFile{Data: good},
+		// Not JSON at all
+		"broken.json": &fstest.MapFile{Data: []byte("{ not json")},
+		// A sigstore bundle wrapping a messageSignature instead of a DSSE
+		// envelope, as found in GitHub releases (eg guacsec/guac)
+		"checksums.txt.bundle": &fstest.MapFile{Data: []byte(
+			`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json",` +
+				`"messageSignature":{"messageDigest":{"algorithm":"SHA2_256",` +
+				`"digest":"6cg="},"signature":"c2ln"}}`,
+		)},
+	}
+
+	collector, err := New(WithFS(fsys))
+	require.NoError(t, err)
+
+	atts, err := collector.Fetch(t.Context(), attestation.FetchOptions{})
+	require.NoError(t, err)
+	require.Len(t, atts, 1)
 }
 
 func TestFetchFetchByPredicateType(t *testing.T) {


### PR DESCRIPTION
This pull request improves the robustness of the `Collector` when handling unparseable files and adds a corresponding test to ensure this behavior. The main changes are focused on error handling and test coverage.

**Error handling improvements:**

* Updated the `Collector.Fetch` method in `collector.go` to log a debug message and skip files that cannot be parsed, instead of failing the entire collection process. This ensures that a single bad file does not interrupt the collection of other valid attestations.
* Added the `logrus` package import to enable debug logging for skipped files.

**Test coverage enhancements:**

* Introduced a new test, `TestFetchSkipsUnparseableFiles`, in `collector_test.go` to verify that the collector skips unparseable files and continues processing valid files. This test uses `fstest.MapFS` to simulate different file scenarios, including a good attestation, a malformed JSON file, and an invalid bundle. [[1]](diffhunk://#diff-926085786ae91329a731137268b0d0c218819bc6521ca6dd8b4ee3144d4d4641R53-R79) [[2]](diffhunk://#diff-926085786ae91329a731137268b0d0c218819bc6521ca6dd8b4ee3144d4d4641R9)