### PR TITLE
Implement missing GetSignatures() in bundles

### DIFF
--- a/envelope/bundle/envelope.go
+++ b/envelope/bundle/envelope.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/carabiner-dev/collector/envelope/dsse"
 	"github.com/carabiner-dev/collector/statement/intoto"
 )
 
@@ -74,8 +75,20 @@ func (e *Envelope) GetCertificate() attestation.Certificate {
 	return nil
 }
 
+// GetSignatures returns the signatures of the DSSE envelope wrapped in the
+// bundle. They are extracted lazily on first call.
 func (e *Envelope) GetSignatures() []attestation.Signature {
-	return nil
+	if e.Signatures == nil {
+		if dsseEnv := e.GetDsseEnvelope(); dsseEnv != nil {
+			for _, s := range dsseEnv.GetSignatures() {
+				e.Signatures = append(e.Signatures, &dsse.Signature{
+					KeyID:     s.GetKeyid(),
+					Signature: s.GetSig(),
+				})
+			}
+		}
+	}
+	return e.Signatures
 }
 
 // GetVerifications returns the signtature verifications stored in the

--- a/envelope/bundle/parser_test.go
+++ b/envelope/bundle/parser_test.go
@@ -24,6 +24,7 @@ func TestParseStream(t *testing.T) {
 			require.Equal(t, attestation.PredicateType("https://slsa.dev/provenance/v0.2"), at[0].GetStatement().GetPredicate().GetType())
 			require.NotNil(t, env.GetStatement())
 			require.Equal(t, attestation.PredicateType("https://slsa.dev/provenance/v0.2"), env.GetStatement().GetPredicateType())
+			require.NotEmpty(t, env.GetSignatures(), "bundle must expose the DSSE envelope signatures")
 		}},
 		{"npm", "testdata/bundle-publish.json", false, func(t *testing.T, at []attestation.Envelope) {
 			t.Helper()


### PR DESCRIPTION
This pull request enhances the handling of DSSE envelope signatures within the bundle envelope implementation. The main improvements are the addition of logic to extract and expose DSSE signatures, and the introduction of a test to ensure this behavior.

**Signature extraction and exposure:**

* Added a new import for the `dsse` package to support DSSE signature handling in `envelope/bundle/envelope.go`.
* Implemented the `GetSignatures` method in the `Envelope` struct to lazily extract signatures from the wrapped DSSE envelope, storing them in the `Signatures` field for future access.

**Testing improvements:**

* Updated the `TestParseStream` test in `envelope/bundle/parser_test.go` to assert that the bundle exposes DSSE envelope signatures, ensuring the new functionality is covered by tests.