### PR TITLE
Treat a not found manifest as "no attestations attached"

### DIFF
--- a/repository/coci/collector.go
+++ b/repository/coci/collector.go
@@ -214,6 +214,11 @@ func (c *Collector) fetchAttestationLayers(ctx context.Context, opts attestation
 		append([]crane.Option{crane.WithContext(ctx)}, c.craneOpts()...)...,
 	)
 	if err != nil {
+		// A missing .att manifest simply means the image has no attestations
+		// attached yet. Treat it as an empty result instead of an error.
+		if isNotFound(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("fetching attestations manifest: %w", err)
 	}
 


### PR DESCRIPTION
This pull request makes a targeted improvement to the `fetchAttestationLayers` function in `collector.go`. The main change is to handle the case where an image does not have an attestation manifest more gracefully, treating it as an empty result rather than an error.

Error handling improvement:

* Updated `fetchAttestationLayers` to treat a missing `.att` manifest (signifying no attestations are attached to the image) as an empty result instead of returning an error. This prevents unnecessary failures when attestations are simply absent.