### PR TITLE
Implement attestation.Storer in release repo collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following table lists all repository drivers currently implemented in the pr
 | **Git Notes** | `note` | Reads and writes attestations stored as git notes on repository commits | `note:git+https://github.com/owner/repo@abc123` or `note:file:///path/to/repo` | ✓ | ✓ |
 | **Dynamic Git Notes** | `dnote` | Dynamically reads and writes attestations from git notes for any commit without preconfiguration | `dnote:https://github.com/owner/repo` | ✓ | ✓ |
 | **OSS Rebuild** | `ossrebuild` | Fetches rebuild attestations from the OSS Rebuild project storage | `ossrebuild:` | ✓ | ✗ |
-| **Release** | `release` | Reads attestations from GitHub release assets | `release:owner/repo@v1.0.0` | ✓ | ✗ |
+| **Release** | `release` | Reads and writes attestations as GitHub release assets | `release:owner/repo@v1.0.0` | ✓ | ✓ |
 
 All of these drivers can be used with tools that use Carabiner's collector such
 as AMPEL or bnd. For more details on each driver see

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -143,6 +143,14 @@ Reads attestations from GitHub release assets. Constructs a virtual
 filesystem from the release's downloadable assets and delegates to the
 **filesystem** collector to parse them.
 
+Also supports storing attestations. When `Store` is called, each envelope is
+JSON-marshaled and uploaded to the release as an individual, content-addressed
+asset named `attestation-<sha256>.json`. Uploads are retried with exponential
+backoff (see `WithRetries`) and an asset that already exists on the release is
+left in place, making `Store` idempotent. A token is required for uploads (and
+for reading private releases); set it with `WithToken` or via the
+`GITHUB_TOKEN` / `GH_TOKEN` environment variables.
+
 ## ossrebuild
 
 Fetches rebuild attestations from the Google OSS Rebuild project. Converts

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.12
 
 require (
 	github.com/carabiner-dev/attestation v0.2.1
-	github.com/carabiner-dev/ghrfs v0.3.4
+	github.com/carabiner-dev/ghrfs v0.3.6
 	github.com/carabiner-dev/github v0.2.3
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/jsonl v0.2.1
@@ -14,6 +14,7 @@ require (
 	github.com/carabiner-dev/sbomfs v0.1.0
 	github.com/carabiner-dev/signer v0.5.3-0.20260719001721-28ad0843d8a9
 	github.com/carabiner-dev/vcslocator v0.4.4
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/github/smimesign v0.2.0
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.19.1
@@ -54,7 +55,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/carabiner-dev/command v0.3.1 // indirect
 	github.com/carabiner-dev/policy v0.5.1 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.12
 
 require (
 	github.com/carabiner-dev/attestation v0.2.1
-	github.com/carabiner-dev/ghrfs v0.3.6
+	github.com/carabiner-dev/ghrfs v0.3.7
 	github.com/carabiner-dev/github v0.2.3
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/jsonl v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/carabiner-dev/attestation v0.2.1 h1:VhjV5YlO9TsW50Sr/Zd54bdbZhhDAqgxC
 github.com/carabiner-dev/attestation v0.2.1/go.mod h1:O84vF84RZG3pJO/6BYrPs718bZviHF5DKajP1HsrDpw=
 github.com/carabiner-dev/command v0.3.1 h1:iBkh+AjwziFZmyihv/izypCV74nkmaslZxb5AgP7GP4=
 github.com/carabiner-dev/command v0.3.1/go.mod h1:0mWfS5BU/krtaI1hgD5wjmLpjWVlf38KY8usA8zfF5c=
-github.com/carabiner-dev/ghrfs v0.3.4 h1:XJoDXkuw+8KQPTC4oI0da8vLpnx7cfQBGgyjzo+Eqrc=
-github.com/carabiner-dev/ghrfs v0.3.4/go.mod h1:u9We7molIUX6sCe4ox70juKOnbNAUpDv+B5Cerbqhio=
+github.com/carabiner-dev/ghrfs v0.3.6 h1:Qu8NZAVTtsRS+D5/0N1fjFkZlhvBRyCPCdjlFUo3Vag=
+github.com/carabiner-dev/ghrfs v0.3.6/go.mod h1:Ax57l8OkALZmIRWfoJwnGYhGjIq1HDox4++8gHiiRio=
 github.com/carabiner-dev/github v0.2.3 h1:sky7HXTrgbk9G9gEWBmIeCExprHdnZvKOsFW1bUZXqc=
 github.com/carabiner-dev/github v0.2.3/go.mod h1:8shcF+ie+DvTTQFP0GUR+Nm67w8AxI/kceqT/vWV39Y=
 github.com/carabiner-dev/hasher v0.2.4 h1:VaI04+FBHaNV/UEy0NmVoRg0pKLFeN76KPOHbTDvvhE=

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/carabiner-dev/command v0.3.1 h1:iBkh+AjwziFZmyihv/izypCV74nkmaslZxb5A
 github.com/carabiner-dev/command v0.3.1/go.mod h1:0mWfS5BU/krtaI1hgD5wjmLpjWVlf38KY8usA8zfF5c=
 github.com/carabiner-dev/ghrfs v0.3.6 h1:Qu8NZAVTtsRS+D5/0N1fjFkZlhvBRyCPCdjlFUo3Vag=
 github.com/carabiner-dev/ghrfs v0.3.6/go.mod h1:Ax57l8OkALZmIRWfoJwnGYhGjIq1HDox4++8gHiiRio=
+github.com/carabiner-dev/ghrfs v0.3.7 h1:P6BVj5LT6yByZZ70AIG5lwKaavFQhD91VDvyYp+xy5A=
+github.com/carabiner-dev/ghrfs v0.3.7/go.mod h1:Ax57l8OkALZmIRWfoJwnGYhGjIq1HDox4++8gHiiRio=
 github.com/carabiner-dev/github v0.2.3 h1:sky7HXTrgbk9G9gEWBmIeCExprHdnZvKOsFW1bUZXqc=
 github.com/carabiner-dev/github v0.2.3/go.mod h1:8shcF+ie+DvTTQFP0GUR+Nm67w8AxI/kceqT/vWV39Y=
 github.com/carabiner-dev/hasher v0.2.4 h1:VaI04+FBHaNV/UEy0NmVoRg0pKLFeN76KPOHbTDvvhE=

--- a/internal/creds/creds.go
+++ b/internal/creds/creds.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package creds resolves API access tokens for VCS hosting providers. It is
+// shared by the collector's provider-specific drivers (GitHub today, GitLab in
+// the future) so token resolution behaves consistently: an explicit token wins,
+// otherwise the first non-empty variable from a provider's conventional
+// environment variables is used.
+package creds
+
+import "os"
+
+// Environment variables that conventionally hold access tokens, by provider.
+// They are ordered by precedence.
+var (
+	GitHubEnvVars = []string{"GITHUB_TOKEN", "GH_TOKEN"}
+	GitLabEnvVars = []string{"GITLAB_TOKEN", "CI_JOB_TOKEN"}
+)
+
+// Token resolves an access token. If explicit is non-empty it is returned
+// unchanged. Otherwise the value of the first non-empty variable in envVars is
+// returned. When nothing is found it returns an empty string; callers decide
+// whether anonymous access is acceptable.
+func Token(explicit string, envVars ...string) string {
+	if explicit != "" {
+		return explicit
+	}
+	for _, name := range envVars {
+		if v := os.Getenv(name); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/creds/creds_test.go
+++ b/internal/creds/creds_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package creds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToken(t *testing.T) {
+	primary, secondary := GitHubEnvVars[0], GitHubEnvVars[1]
+	for _, tc := range []struct {
+		name     string
+		explicit string
+		env      map[string]string
+		lookup   []string
+		expect   string
+	}{
+		{
+			name:     "explicit-wins-over-env",
+			explicit: "explicit",
+			env:      map[string]string{primary: "from-env"},
+			lookup:   []string{primary},
+			expect:   "explicit",
+		},
+		{
+			name:   "first-env-var-set",
+			env:    map[string]string{primary: "", secondary: "gh"},
+			lookup: GitHubEnvVars,
+			expect: "gh",
+		},
+		{
+			name:   "env-precedence-order",
+			env:    map[string]string{primary: "primary-tok", secondary: "secondary-tok"},
+			lookup: GitHubEnvVars,
+			expect: "primary-tok",
+		},
+		{
+			name:   "nothing-set",
+			env:    map[string]string{primary: "", secondary: ""},
+			lookup: GitHubEnvVars,
+			expect: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			require.Equal(t, tc.expect, Token(tc.explicit, tc.lookup...))
+		})
+	}
+}

--- a/repository/release/collector.go
+++ b/repository/release/collector.go
@@ -26,7 +26,9 @@ var Build = func(istr string) (attestation.Repository, error) {
 
 func New(funcs ...optFn) (*Collector, error) {
 	c := &Collector{
-		Options: defaultOptions,
+		Options:        defaultOptions,
+		apiBaseURL:     defaultAPIBaseURL,
+		uploadsBaseURL: defaultUploadsBaseURL,
 	}
 	for _, fn := range funcs {
 		if err := fn(c); err != nil {
@@ -42,6 +44,7 @@ func New(funcs ...optFn) (*Collector, error) {
 		ghrfs.FromURL(
 			fmt.Sprintf("%s/releases/tag/%s", c.Options.RepoURL, c.Options.Tag),
 		),
+		ghrfs.WithToken(c.Options.Token),
 		ghrfs.WithCache(true),
 		ghrfs.WithCacheExtensions(
 			[]string{"jsonl", "json", "pub", "sig", "crt", "key", "pub", "pem", "spdx", "cdx", "bundle", "asc", "gpg"},
@@ -67,6 +70,11 @@ type Collector struct {
 	Options Options
 	Keys    []key.PublicKeyProvider
 	Driver  attestation.Fetcher
+
+	// GitHub REST hosts used when uploading attestations (Store). They default
+	// to the public GitHub endpoints and are overridable in tests.
+	apiBaseURL     string
+	uploadsBaseURL string
 }
 
 // SetKeys sets the verification keys on the release collector and propagates

--- a/repository/release/collector.go
+++ b/repository/release/collector.go
@@ -45,6 +45,7 @@ func New(funcs ...optFn) (*Collector, error) {
 			fmt.Sprintf("%s/releases/tag/%s", c.Options.RepoURL, c.Options.Tag),
 		),
 		ghrfs.WithToken(c.Options.Token),
+		ghrfs.WithRetries(c.Options.Retries),
 		ghrfs.WithCache(true),
 		ghrfs.WithCacheExtensions(
 			[]string{"jsonl", "json", "pub", "sig", "crt", "key", "pub", "pem", "spdx", "cdx", "bundle", "asc", "gpg"},

--- a/repository/release/options.go
+++ b/repository/release/options.go
@@ -26,7 +26,8 @@ type Options struct {
 	// GITHUB_TOKEN / GH_TOKEN environment variables are used as a fallback.
 	Token string
 	// Retries is the number of additional attempts (with exponential backoff)
-	// made for each release API request when uploading attestations.
+	// made for each release API request, both when reading a release (fetch)
+	// and when uploading attestations (store).
 	Retries uint
 }
 
@@ -84,8 +85,9 @@ func WithToken(token string) optFn {
 	}
 }
 
-// WithRetries sets how many times an upload request is retried (with
-// exponential backoff) before giving up. Zero disables retries.
+// WithRetries sets how many times a release request is retried (with
+// exponential backoff) before giving up, for both fetch and store operations.
+// Zero disables retries.
 func WithRetries(n uint) optFn {
 	return func(c *Collector) error {
 		c.Options.Retries = n

--- a/repository/release/options.go
+++ b/repository/release/options.go
@@ -12,7 +12,8 @@ import (
 )
 
 var defaultOptions = Options{
-	Tag: "latest",
+	Tag:     "latest",
+	Retries: 5,
 }
 
 type optFn = func(*Collector) error
@@ -20,6 +21,13 @@ type optFn = func(*Collector) error
 type Options struct {
 	RepoURL string
 	Tag     string
+	// Token authenticates GitHub API requests. It is required to upload
+	// attestations (Store) and to read from private releases. When empty, the
+	// GITHUB_TOKEN / GH_TOKEN environment variables are used as a fallback.
+	Token string
+	// Retries is the number of additional attempts (with exponential backoff)
+	// made for each release API request when uploading attestations.
+	Retries uint
 }
 
 // WithInitURL is specially crafte
@@ -61,6 +69,26 @@ func WithTag(tag string) optFn {
 func WithKey(keys ...key.PublicKeyProvider) optFn {
 	return func(c *Collector) error {
 		c.Keys = append(c.Keys, keys...)
+		return nil
+	}
+}
+
+// WithToken sets the access token used to authenticate against GitHub. It is
+// required to upload attestations to a release and to read from private
+// releases. When unset, the GITHUB_TOKEN / GH_TOKEN environment variables are
+// used as a fallback.
+func WithToken(token string) optFn {
+	return func(c *Collector) error {
+		c.Options.Token = token
+		return nil
+	}
+}
+
+// WithRetries sets how many times an upload request is retried (with
+// exponential backoff) before giving up. Zero disables retries.
+func WithRetries(n uint) optFn {
+	return func(c *Collector) error {
+		c.Options.Retries = n
 		return nil
 	}
 }

--- a/repository/release/storer.go
+++ b/repository/release/storer.go
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package release
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/carabiner-dev/attestation"
+	"github.com/cenkalti/backoff/v5"
+
+	"github.com/carabiner-dev/collector/internal/creds"
+)
+
+const (
+	defaultAPIBaseURL     = "https://api.github.com"
+	defaultUploadsBaseURL = "https://uploads.github.com"
+	githubAPIVersion      = "2022-11-28"
+
+	// maxResponseSize bounds how much of a GitHub API response is read into
+	// memory when resolving a release.
+	maxResponseSize = 4 << 20 // 4 MiB
+)
+
+var _ attestation.Storer = (*Collector)(nil)
+
+// Store implements the attestation.Storer interface. Each envelope is uploaded
+// to the GitHub release identified by the collector's repository and tag as an
+// individual, content-addressed release asset named "attestation-<sha256>.json".
+// Uploads are retried with exponential backoff (see WithRetries) and any asset
+// already present on the release is left in place, making Store idempotent.
+//
+// A token is required (WithToken, or the GITHUB_TOKEN / GH_TOKEN environment
+// variables); GitHub does not permit anonymous writes.
+func (c *Collector) Store(ctx context.Context, _ attestation.StoreOptions, envelopes []attestation.Envelope) error {
+	if len(envelopes) == 0 {
+		return nil
+	}
+
+	owner, repo, err := c.ownerRepo()
+	if err != nil {
+		return err
+	}
+
+	token := creds.Token(c.Options.Token, creds.GitHubEnvVars...)
+	if token == "" {
+		return errors.New(
+			"a token is required to upload attestations to a release; set it with " +
+				"WithToken or via the GITHUB_TOKEN environment variable",
+		)
+	}
+
+	releaseID, err := c.fetchReleaseID(ctx, token, owner, repo)
+	if err != nil {
+		return fmt.Errorf("resolving release %q: %w", c.Options.Tag, err)
+	}
+
+	for i, env := range envelopes {
+		data, err := json.Marshal(env)
+		if err != nil {
+			return fmt.Errorf("marshaling envelope #%d: %w", i, err)
+		}
+		name := assetName(data)
+		if err := c.uploadAsset(ctx, token, owner, repo, releaseID, name, data); err != nil {
+			return fmt.Errorf("uploading attestation %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// ownerRepo extracts the owner and repository slug from the configured repo URL.
+func (c *Collector) ownerRepo() (owner, repo string, err error) {
+	u, err := url.Parse(c.Options.RepoURL)
+	if err != nil {
+		return "", "", fmt.Errorf("parsing repository URL %q: %w", c.Options.RepoURL, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("repository URL %q does not contain an owner and repo", c.Options.RepoURL)
+	}
+	return parts[0], parts[1], nil
+}
+
+// fetchReleaseID resolves the numeric id of the release for the configured tag.
+func (c *Collector) fetchReleaseID(ctx context.Context, token, owner, repo string) (int64, error) {
+	endpoint := fmt.Sprintf(
+		"%s/repos/%s/%s/releases/tags/%s",
+		c.apiBaseURL, owner, repo, url.PathEscape(c.Options.Tag),
+	)
+	// The tagged-release endpoint does not resolve "latest"; use the dedicated
+	// endpoint for it, mirroring how the collector reads releases.
+	if c.Options.Tag == "" || c.Options.Tag == "latest" {
+		endpoint = fmt.Sprintf("%s/repos/%s/%s/releases/latest", c.apiBaseURL, owner, repo)
+	}
+
+	body, err := withRetry(ctx, c.Options.Retries, func() ([]byte, error) {
+		resp, err := c.ghRequest(ctx, http.MethodGet, endpoint, token, "", nil)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close() //nolint:errcheck
+		return readResponse(resp, maxResponseSize)
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	var rel struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(body, &rel); err != nil {
+		return 0, fmt.Errorf("decoding release response: %w", err)
+	}
+	if rel.ID == 0 {
+		return 0, fmt.Errorf("release for tag %q not found", c.Options.Tag)
+	}
+	return rel.ID, nil
+}
+
+// uploadAsset uploads a single asset to the release. An asset that already
+// exists (HTTP 422) is treated as success so repeated Store calls are
+// idempotent.
+func (c *Collector) uploadAsset(ctx context.Context, token, owner, repo string, releaseID int64, name string, data []byte) error {
+	endpoint := fmt.Sprintf(
+		"%s/repos/%s/%s/releases/%d/assets?name=%s",
+		c.uploadsBaseURL, owner, repo, releaseID, url.QueryEscape(name),
+	)
+
+	_, err := withRetry(ctx, c.Options.Retries, func() ([]byte, error) {
+		resp, err := c.ghRequest(ctx, http.MethodPost, endpoint, token, "application/json", data)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close() //nolint:errcheck
+		// The asset is already on the release; nothing more to do.
+		if resp.StatusCode == http.StatusUnprocessableEntity {
+			return nil, nil
+		}
+		return readResponse(resp, maxResponseSize)
+	})
+	return err
+}
+
+// ghRequest issues an authenticated GitHub REST request. It does not interpret
+// the status code; callers use readResponse to turn HTTP errors into (retryable
+// or permanent) Go errors.
+func (c *Collector) ghRequest(ctx context.Context, method, endpoint, token, contentType string, body []byte) (*http.Response, error) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return nil, backoff.Permanent(fmt.Errorf("building request: %w", err))
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-Github-Api-Version", githubAPIVersion)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return http.DefaultClient.Do(req)
+}
+
+// readResponse reads and returns the body of a successful response. Non-2xx
+// responses become errors: client errors (4xx other than 429) are marked
+// permanent so they are not retried, while 429 and 5xx errors are retryable.
+func readResponse(resp *http.Response, limit int64) ([]byte, error) {
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, limit))
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		if readErr != nil {
+			return nil, fmt.Errorf("reading response body: %w", readErr)
+		}
+		return body, nil
+	}
+
+	err := fmt.Errorf("github returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	if resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		return nil, backoff.Permanent(err)
+	}
+	return nil, err
+}
+
+// withRetry runs op with exponential backoff, attempting it up to retries+1
+// times. Errors wrapped with backoff.Permanent stop the retry loop early.
+func withRetry(ctx context.Context, retries uint, op func() ([]byte, error)) ([]byte, error) {
+	return backoff.Retry(
+		ctx, op,
+		backoff.WithBackOff(backoff.NewExponentialBackOff()),
+		backoff.WithMaxTries(retries+1),
+	)
+}
+
+// assetName returns a stable, content-addressed release-asset name for the
+// given envelope bytes. Using the content digest keeps uploads idempotent:
+// re-storing identical bytes resolves to the same asset name.
+func assetName(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("attestation-%s.json", hex.EncodeToString(sum[:])[:16])
+}

--- a/repository/release/storer_test.go
+++ b/repository/release/storer_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/carabiner-dev/attestation"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeEnvelope is a minimal attestation.Envelope for exercising Store. Only its
+// JSON marshaling matters; Store never calls the interface methods.
+type fakeEnvelope struct {
+	Payload string `json:"payload"`
+}
+
+func (fakeEnvelope) GetStatement() attestation.Statement       { return nil }
+func (fakeEnvelope) GetPredicate() attestation.Predicate       { return nil }
+func (fakeEnvelope) GetSignatures() []attestation.Signature    { return nil }
+func (fakeEnvelope) GetCertificate() attestation.Certificate   { return nil }
+func (fakeEnvelope) GetVerification() attestation.Verification { return nil }
+func (fakeEnvelope) Verify(...any) error                       { return nil }
+
+func testCollector(serverURL string) *Collector {
+	return &Collector{
+		Options: Options{
+			RepoURL: "https://github.com/example/repo",
+			Tag:     "v1.0.0",
+			Token:   "s3cr3t",
+		},
+		apiBaseURL:     serverURL,
+		uploadsBaseURL: serverURL,
+	}
+}
+
+// writeReleaseID responds with a release lookup payload. t.Errorf is safe to
+// call from the server's goroutine (unlike t.Fatal).
+func writeReleaseID(t *testing.T, w http.ResponseWriter, id int64) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(map[string]any{"id": id}); err != nil {
+		t.Errorf("encoding release response: %v", err)
+	}
+}
+
+func TestStore(t *testing.T) {
+	t.Run("uploads-each-envelope", func(t *testing.T) {
+		var mu sync.Mutex
+		uploads := map[string][]byte{}
+		var relAuth, uploadContentType string
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/example/repo/releases/tags/v1.0.0", func(w http.ResponseWriter, r *http.Request) {
+			relAuth = r.Header.Get("Authorization")
+			writeReleaseID(t, w, 4242)
+		})
+		mux.HandleFunc("POST /repos/example/repo/releases/4242/assets", func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("reading upload body: %v", err)
+			}
+			mu.Lock()
+			uploads[r.URL.Query().Get("name")] = body
+			uploadContentType = r.Header.Get("Content-Type")
+			mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		err := testCollector(srv.URL).Store(context.Background(), attestation.StoreOptions{}, []attestation.Envelope{
+			fakeEnvelope{Payload: "one"},
+			fakeEnvelope{Payload: "two"},
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, "Bearer s3cr3t", relAuth)
+		require.Equal(t, "application/json", uploadContentType)
+		require.Len(t, uploads, 2)
+		for name, body := range uploads {
+			require.True(t, strings.HasPrefix(name, "attestation-"), "unexpected asset name %q", name)
+			require.True(t, strings.HasSuffix(name, ".json"), "unexpected asset name %q", name)
+			require.Contains(t, string(body), `"payload"`)
+		}
+	})
+
+	t.Run("errors-without-token", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GH_TOKEN", "")
+		c := testCollector("http://127.0.0.1:0")
+		c.Options.Token = ""
+		err := c.Store(context.Background(), attestation.StoreOptions{}, []attestation.Envelope{fakeEnvelope{}})
+		require.ErrorContains(t, err, "token is required")
+	})
+
+	t.Run("noop-on-empty", func(t *testing.T) {
+		require.NoError(t, testCollector("http://127.0.0.1:0").Store(
+			context.Background(), attestation.StoreOptions{}, nil,
+		))
+	})
+
+	t.Run("existing-asset-is-idempotent", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/example/repo/releases/tags/v1.0.0", func(w http.ResponseWriter, _ *http.Request) {
+			writeReleaseID(t, w, 4242)
+		})
+		mux.HandleFunc("POST /repos/example/repo/releases/4242/assets", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, `{"message":"Validation Failed","errors":[{"code":"already_exists"}]}`, http.StatusUnprocessableEntity)
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		err := testCollector(srv.URL).Store(context.Background(), attestation.StoreOptions{}, []attestation.Envelope{fakeEnvelope{Payload: "x"}})
+		require.NoError(t, err)
+	})
+
+	t.Run("retries-transient-upload-error", func(t *testing.T) {
+		var attempts atomic.Int32
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/example/repo/releases/tags/v1.0.0", func(w http.ResponseWriter, _ *http.Request) {
+			writeReleaseID(t, w, 4242)
+		})
+		mux.HandleFunc("POST /repos/example/repo/releases/4242/assets", func(w http.ResponseWriter, _ *http.Request) {
+			if attempts.Add(1) == 1 {
+				http.Error(w, "boom", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		c := testCollector(srv.URL)
+		c.Options.Retries = 3
+		require.NoError(t, c.Store(context.Background(), attestation.StoreOptions{}, []attestation.Envelope{fakeEnvelope{Payload: "x"}}))
+		require.Equal(t, int32(2), attempts.Load())
+	})
+}


### PR DESCRIPTION
This PR adds store support to the releases repository collector.

As we are adding a WithRetries() option we now leverage the latest release of carabiner-dev/ghrfs to add retries support to the fetch operations too with the shared option value.